### PR TITLE
WIP chore: add version and publish scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "gm-ui-components",
   "version": "0.3.0",
-  "description": "A library of reusable UI components for the Grey Matter product suite.",
+  "description":
+    "A library of reusable UI components for the Grey Matter product suite.",
   "main": "lib/build.js",
   "author": "Decipher Technology Studios",
   "license": "Apache-2.0",
@@ -9,9 +10,7 @@
     "type": "git",
     "url": "git@github.com:DecipherNow/gm-ui-components.git"
   },
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "dependencies": {
     "polished": "^1.9.0",
     "prop-types": "^15.6.0",
@@ -27,7 +26,9 @@
     "deploy-storybook": "storybook-to-ghpages",
     "junit-merge": "junit-merge",
     "lint-js": "node ./node_modules/eslint/bin/eslint 'src'",
+    "preversion": "npm test",
     "prepublishonly": "npm run build",
+    "postpublish": "npm run deploy-storybook",
     "start": "webpack -w",
     "storybook": "start-storybook -p 9009 -s public",
     "test": "jest",
@@ -71,15 +72,9 @@
     "useTabs": false
   },
   "jest": {
-    "collectCoverageFrom": [
-      "src/components/**/*.{js,jsx}"
-    ],
+    "collectCoverageFrom": ["src/components/**/*.{js,jsx}"],
     "setupTestFrameworkScriptFile": "<rootDir>/config/setupTests.js",
-    "unmockedModulePathPatterns": [
-      "react",
-      "enzyme",
-      "jest-enzyme"
-    ],
+    "unmockedModulePathPatterns": ["react", "enzyme", "jest-enzyme"],
     "moduleNameMapper": {
       "\\.(css|jpg|png|svg|ttf)$": "<rootDir>/config/emptyModule.js"
     },
@@ -87,9 +82,7 @@
       "<rootDir>/src/**/__tests__/**/*.js?(x)",
       "<rootDir>/src/**/?(*.)(spec|test).js?(x)"
     ],
-    "setupFiles": [
-      "raf/polyfill"
-    ]
+    "setupFiles": ["raf/polyfill"]
   },
   "engines": {
     "node": ">=8.6.0",


### PR DESCRIPTION
`preversion` script that runs tests and only bumps the version if they pass
`postpublish` script that deploys storybook

I'm thinking that once the changelog script is merged in I can add that to a `postversion` script