### PR TITLE
feat: add ButtonGroup

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,7 +1,6 @@
 import { PropTypes } from "prop-types";
 import React from "react";
 
-import Icon from "../Icon";
 import * as Glyphs from "../Glyphs";
 
 import ButtonWrap from "./components/ButtonWrap";
@@ -15,8 +14,7 @@ Button.propTypes = {
   disabled: PropTypes.bool, // disables the button
   glyph: PropTypes.string, // Glyph to display in the button
   glyphColor: PropTypes.string, // Color for the glyph
-  glyphRatio: PropTypes.oneOfType([PropTypes.string, PropTypes.number]), // Relative size for the glyph
-  iconSize: PropTypes.oneOf(["normal", "xs", "sm", "lg", "xl"]),
+  glyphSize: PropTypes.oneOf(["normal", "xs", "sm", "lg", "xl"]),
   label: PropTypes.string.isRequired, // label for the button
   labelStyle: PropTypes.object,
   orientation: PropTypes.oneOf(["vertical", "horizontal"]), // Vertical: Icon top, label bottom; Horizontal: Icon left, label right;
@@ -63,7 +61,7 @@ export default function Button({
   glyph,
   glyphRatio,
   glyphColor,
-  iconSize,
+  glyphSize,
   label,
   orientation,
   prefix,
@@ -88,9 +86,9 @@ export default function Button({
       tabIndex={tabIndex}
       title={label}
       style={style}
-      iconSize={iconSize}
+      glyphSize={glyphSize}
     >
-      {Glyph && <Glyph glyphColor={glyphColor} glyphSizeRatio={glyphRatio} />}
+      {Glyph && <Glyph glyphColor={glyphColor} />}
       {children}
       <span style={labelStyle}>
         {prefix ? <ButtonLabelPrefix>{prefix}</ButtonLabelPrefix> : ""}

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -59,7 +59,6 @@ export default function Button({
   clickAction,
   disabled,
   glyph,
-  glyphRatio,
   glyphColor,
   glyphSize,
   label,

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -15,8 +15,7 @@ const props = {
   disabled: false,
   glyph: "Bell",
   glyphColor: "#fff",
-  glyphRatio: 1,
-  iconSize: "sm",
+  glyphSize: "sm",
   label: "Button",
   labelStyle: {},
   orientation: "horizontal",
@@ -114,7 +113,7 @@ describe("Button", () => {
       expect(wrapper.find(ButtonWrap).props()).toMatchObject({
         active: false,
         disabled: false,
-        iconSize: "sm",
+        glyphSize: "sm",
         onClick: wrapper.props().clickAction,
         orientation: "horizontal",
         outline: "outline",
@@ -128,8 +127,7 @@ describe("Button", () => {
 
     test("passes correct props to Bell glyph", () => {
       expect(wrapper.find("Bell").props()).toMatchObject({
-        glyphColor: "#fff",
-        glyphSizeRatio: 1
+        glyphColor: "#fff"
       });
     });
 

--- a/src/components/Button/components/ButtonWrap/ButtonWrap.js
+++ b/src/components/Button/components/ButtonWrap/ButtonWrap.js
@@ -97,9 +97,9 @@ const ButtonWrap = styled.button`
         : generateButtonSize() // Icons // no size
     } 
     ${
-      props.iconSize
-        ? generateButtonIconRatio(props.iconSize) // has iconSize
-        : generateButtonIconRatio() // Orientation // no iconSize
+      props.glyphSize
+        ? generateButtonIconRatio(props.glyphSize) // has glyphSize
+        : generateButtonIconRatio() // Orientation // no glyphSize
     } 
     ${
       props.orientation

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import { PropTypes } from "prop-types";
+
+import { spacingScale } from "../../style/styleFunctions";
+
+const ButtonGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+  * + * {
+    margin-left: ${spacingScale(0.5)};
+  }
+  ${props => props.style};
+`;
+
+ButtonGroup.propTypes = {
+  style: PropTypes.object
+};
+
+export default ButtonGroup;

--- a/src/components/ButtonGroup/ButtonGroup.js
+++ b/src/components/ButtonGroup/ButtonGroup.js
@@ -12,6 +12,8 @@ const ButtonGroup = styled.div`
   ${props => props.style};
 `;
 
+ButtonGroup.displayName = "ButtonGroup";
+
 ButtonGroup.propTypes = {
   style: PropTypes.object
 };

--- a/src/components/ButtonGroup/ButtonGroup.test.js
+++ b/src/components/ButtonGroup/ButtonGroup.test.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { shallow } from "enzyme";
+import ButtonGroup from "./ButtonGroup";
+
+describe("ButtonGroup", () => {
+  it("matches snapshot", () => {
+    const aButtonGroup = shallow(<ButtonGroup />);
+    expect(aButtonGroup).toMatchSnapshot();
+  });
+});

--- a/src/components/ButtonGroup/ButtonGroup.test.js
+++ b/src/components/ButtonGroup/ButtonGroup.test.js
@@ -1,10 +1,11 @@
 import React from "react";
-import { shallow } from "enzyme";
+import renderer from "react-test-renderer";
 import ButtonGroup from "./ButtonGroup";
+import "jest-styled-components";
 
 describe("ButtonGroup", () => {
   it("matches snapshot", () => {
-    const aButtonGroup = shallow(<ButtonGroup />);
+    const aButtonGroup = renderer.create(<ButtonGroup />).toJSON();
     expect(aButtonGroup).toMatchSnapshot();
   });
 });

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ButtonGroup matches snapshot 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <styled.div />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "className": "sc-bdVaJa cHlGlT",
+    },
+    "ref": null,
+    "rendered": null,
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "className": "sc-bdVaJa cHlGlT",
+      },
+      "ref": null,
+      "rendered": null,
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -4,7 +4,7 @@ exports[`ButtonGroup matches snapshot 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <styled.div />,
+  Symbol(enzyme.__unrendered__): <ButtonGroup />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "getNode": [Function],

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.js.snap
@@ -1,47 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ButtonGroup matches snapshot 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <ButtonGroup />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "host",
-    "props": Object {
-      "className": "sc-bdVaJa cHlGlT",
-    },
-    "ref": null,
-    "rendered": null,
-    "type": "div",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "className": "sc-bdVaJa cHlGlT",
-      },
-      "ref": null,
-      "rendered": null,
-      "type": "div",
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
 }
+
+.c0 * + * {
+  margin-left: 4px;
+}
+
+<div
+  className="c0"
+/>
 `;

--- a/src/components/ButtonGroup/index.js
+++ b/src/components/ButtonGroup/index.js
@@ -1,0 +1,2 @@
+import ButtonGroup from "./ButtonGroup";
+export default ButtonGroup;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,6 +3,7 @@ import { injectGlobal } from "styled-components";
 import { AppFooter } from "./AppFooter";
 import { Breadcrumbs, BreadcrumbItem } from "./Breadcrumbs";
 import Button from "./Button";
+import ButtonGroup from "./ButtonGroup";
 import { Checkbox } from "./Checkbox";
 import { Input } from "./Input";
 import Icon from "./Icon";
@@ -17,7 +18,7 @@ import "../style/fonts/Metropolis";
 import "../style/fonts/Source_Code_Pro";
 
 injectGlobal`
-*{
+* {
   box-sizing: border-box;
 }
 @font-face {
@@ -35,6 +36,7 @@ const library = {
   Icon,
   Input,
   Button,
+  ButtonGroup,
   Breadcrumbs,
   BreadcrumbItem,
   Tooltip

--- a/src/stories/Button.story.js
+++ b/src/stories/Button.story.js
@@ -90,7 +90,7 @@ storiesOf("Button", module)
           type={select("type", types, "default")}
           glyph={select("glyph", glyphNames)}
           glyphColor={color("glyphColor")}
-          glyphRatio={number("glyphRatio", 1)}
+          glyphSize={select("glyphSize", sizes)}
           disabled={boolean("disabled", false)}
           clickAction={() => alert("clicked")}
           orientation={select("orientation", orientations, "horizontal")}

--- a/src/stories/ButtonGroup.story.js
+++ b/src/stories/ButtonGroup.story.js
@@ -8,17 +8,17 @@ import ButtonGroup from "../components/ButtonGroup";
 
 storiesOf("Button Group", module)
   .addDecorator(withKnobs)
-  .addDecorator(
+  .add(
+    "default",
     withInfo(
       "An ButtonGroup component that takes any number of Button components as children"
-    )
-  )
-  .add("default", () => {
-    return (
-      <ButtonGroup>
-        <Button label="Button #1" />
-        <Button label="Button #2" />
-        <Button label="Button #3" />
-      </ButtonGroup>
-    );
-  });
+    )(() => {
+      return (
+        <ButtonGroup>
+          <Button label="Button #1" />
+          <Button label="Button #2" />
+          <Button label="Button #3" />
+        </ButtonGroup>
+      );
+    })
+  );

--- a/src/stories/ButtonGroup.story.js
+++ b/src/stories/ButtonGroup.story.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { withKnobs } from "@storybook/addon-knobs/react";
+import { withInfo } from "@storybook/addon-info";
+
+import Button from "../components/Button";
+import ButtonGroup from "../components/ButtonGroup";
+
+storiesOf("Button Group", module)
+  .addDecorator(withKnobs)
+  .addDecorator(
+    withInfo(
+      "An ButtonGroup component that takes any number of Button components as children"
+    )
+  )
+  .add("default", () => {
+    return (
+      <ButtonGroup>
+        <Button label="Button #1" />
+        <Button label="Button #2" />
+        <Button label="Button #3" />
+      </ButtonGroup>
+    );
+  });

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -1,6 +1,7 @@
 import "./AppFooter.story.js";
 import "./Breadcrumbs.story.js";
 import "./Button.story.js";
+import "./ButtonGroup.story.js";
 import "./Input.story.js";
 import "./Icon.story.js";
 import "./Checkbox.story.js";


### PR DESCRIPTION
### Changes
- It turns out we had both an iconSize and glyphRatio prop for our button, which was part of the confusion. I got rid of glyphRatio and correctly implemented iconSize. Now we can independently control button size and the glyph size, and they'll actually work together.
- Renamed `iconSize` to `glyphSize`, since that made more sense to me in the context of our other props.
- Added tests, storybook
