### PR TITLE
fix: add missing ZINDEX_STICKY

### DIFF
--- a/src/components/AppFooter/__snapshots__/AppFooter.test.js.snap
+++ b/src/components/AppFooter/__snapshots__/AppFooter.test.js.snap
@@ -139,6 +139,7 @@ exports[`A Footer container should render 1`] = `
     bottom: 0;
     left: 0;
     right: 0;
+    z-index: 1010;
   }
 
   .c0 + * {

--- a/src/components/AppFooter/components/__snapshots__/Footer.test.js.snap
+++ b/src/components/AppFooter/components/__snapshots__/Footer.test.js.snap
@@ -46,6 +46,7 @@ exports[`Footer should render 1`] = `
     bottom: 0;
     left: 0;
     right: 0;
+    z-index: 1010;
   }
 
   .c0 + * {

--- a/src/style/styleVariables.js
+++ b/src/style/styleVariables.js
@@ -14,7 +14,6 @@ export const COLOR_DANGER = COLOR_RED;
 export const COLOR_WARNING = "#f8b400";
 export const COLOR_INFO = "#094dff";
 
-
 export const DARK_ON_LIGHT_CONTRAST_ENHANCEMENT_RATIO = 2;
 
 /*/ Theme Configuration /*/
@@ -31,7 +30,7 @@ export const PADDING_BASE = 8;
 
 // z-index mappings
 export const ZINDEX_TOOLTIP = "1070";
-
+export const ZINDEX_STICKY = "1010";
 /*/ Fonts /*/
 
 // Backup font list


### PR DESCRIPTION
AppFooter was using ZINDEX_STICKY, but that was not in our styleVariables