### PR TITLE
feat: add spinner

### DIFF
--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+import Rotate360 from "./components/Rotate360";
+
+const Spinner = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-top: -30px;
+  margin-left: -30px;
+  width: 60px;
+  height: 60px;
+  font-size: 8px;
+  text-indent: -9999em;
+  border-top: 1.1em solid rgba(0, 0, 0, 0.2);
+  border-right: 1.1em solid rgba(0, 0, 0, 0.2);
+  border-bottom: 1.1em solid rgba(0, 0, 0, 0.2);
+  border-left: 1.1em solid #000000;
+  transform: translateZ(0);
+  animation: ${Rotate360} 1.1s infinite linear;
+  border-radius: 50%;
+`;
+
+export default Spinner;

--- a/src/components/Spinner/Spinner.stories.js
+++ b/src/components/Spinner/Spinner.stories.js
@@ -1,0 +1,6 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import Spinner from "./Spinner";
+
+storiesOf("Spinner", module).add("default", () => <Spinner />);

--- a/src/components/Spinner/Spinner.test.js
+++ b/src/components/Spinner/Spinner.test.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Spinner from "./Spinner";
+
+describe("Spinner", () => {
+  it("matches snapshot", () => {
+    const aSpinner = shallow(<Spinner />);
+    expect(aSpinner).toMatchSnapshot();
+  });
+});

--- a/src/components/Spinner/__snapshots__/Spinner.test.js.snap
+++ b/src/components/Spinner/__snapshots__/Spinner.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spinner matches snapshot 1`] = `
+.c0 {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-top: -30px;
+  margin-left: -30px;
+  width: 60px;
+  height: 60px;
+  font-size: 8px;
+  text-indent: -9999em;
+  border-top: 1.1em solid rgba(0,0,0,0.2);
+  border-right: 1.1em solid rgba(0,0,0,0.2);
+  border-bottom: 1.1em solid rgba(0,0,0,0.2);
+  border-left: 1.1em solid #000000;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation: iECmZH 1.1s infinite linear;
+  animation: iECmZH 1.1s infinite linear;
+  border-radius: 50%;
+}
+
+<div
+  className="c0"
+/>
+`;

--- a/src/components/Spinner/components/Rotate360.js
+++ b/src/components/Spinner/components/Rotate360.js
@@ -1,0 +1,12 @@
+import { keyframes } from "styled-components";
+
+const Rotate360 = keyframes`
+0% {
+  transform: rotate(0deg);
+}
+100% {
+  transform: rotate(360deg);
+}
+`;
+
+export default Rotate360;

--- a/src/components/Spinner/index.js
+++ b/src/components/Spinner/index.js
@@ -1,0 +1,3 @@
+import Spinner from "./Spinner";
+
+export default Spinner;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,11 +3,12 @@ import { Breadcrumbs, BreadcrumbItem } from "./Breadcrumbs";
 import Button from "./Button";
 import ButtonGroup from "./ButtonGroup";
 import { Checkbox } from "./Checkbox";
-import { Input } from "./Input";
 import Icon from "./Icon";
-import Tooltip from "./Tooltip";
+import { Input } from "./Input";
+import Spinner from "./Spinner";
 import Tab from "./Tab";
 import TabGroup from "./TabGroup";
+import Tooltip from "./Tooltip";
 
 import * as Glyphs from "./Glyphs";
 
@@ -21,6 +22,7 @@ const library = {
   ButtonGroup,
   Breadcrumbs,
   BreadcrumbItem,
+  Spinner,
   Tooltip,
   Tab,
   TabGroup


### PR DESCRIPTION
I propose that we add the spinner from `gm-fabric-dashboard`. It's pretty general purpose and seems like something that should be generally consistent across UIs.