### PR TITLE
fix: icon cleanup

### DIFF
--- a/src/components/AppFooter/__snapshots__/AppFooter.test.js.snap
+++ b/src/components/AppFooter/__snapshots__/AppFooter.test.js.snap
@@ -185,7 +185,7 @@ exports[`A Footer container should render 1`] = `
       title="Decipher Technology Studios Github"
     >
       <svg
-        aria-labelledby="ariaLabelledby"
+        aria-labelledby="GitHub"
         className="c5"
         focusable="false"
         preserveAspectRatio="xMaxYMax meet"
@@ -217,7 +217,7 @@ exports[`A Footer container should render 1`] = `
       title="Decipher Technology Studios Twitter"
     >
       <svg
-        aria-labelledby="ariaLabelledby"
+        aria-labelledby="Twitter"
         className="c5"
         focusable="false"
         preserveAspectRatio="xMaxYMax meet"
@@ -249,7 +249,7 @@ exports[`A Footer container should render 1`] = `
       title="Decipher Technology Studios LinkedIn"
     >
       <svg
-        aria-labelledby="ariaLabelledby"
+        aria-labelledby="LinkedIn"
         className="c5"
         focusable="false"
         preserveAspectRatio="xMaxYMax meet"

--- a/src/components/AppFooter/__snapshots__/AppFooter.test.js.snap
+++ b/src/components/AppFooter/__snapshots__/AppFooter.test.js.snap
@@ -185,7 +185,6 @@ exports[`A Footer container should render 1`] = `
       title="Decipher Technology Studios Github"
     >
       <svg
-        aria-labelledby="GitHub"
         className="c5"
         focusable="false"
         preserveAspectRatio="xMaxYMax meet"
@@ -217,7 +216,6 @@ exports[`A Footer container should render 1`] = `
       title="Decipher Technology Studios Twitter"
     >
       <svg
-        aria-labelledby="Twitter"
         className="c5"
         focusable="false"
         preserveAspectRatio="xMaxYMax meet"
@@ -249,7 +247,6 @@ exports[`A Footer container should render 1`] = `
       title="Decipher Technology Studios LinkedIn"
     >
       <svg
-        aria-labelledby="LinkedIn"
         className="c5"
         focusable="false"
         preserveAspectRatio="xMaxYMax meet"

--- a/src/components/Glyphs/__snapshots__/Bars.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Bars.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Bars matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Bell.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Bell.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Bell matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/CPU.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/CPU.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`CPU matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Card.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Card.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Card matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Close.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Close.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Close matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Cog.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Cog.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Cog matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Configuration.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Configuration.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Configuration matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Docs.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Docs.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Docs matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/EKG.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/EKG.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`EKG matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/EditGraph.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/EditGraph.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`EditGraph matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/ErrorList.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/ErrorList.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`ErrorList matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Exclamation.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Exclamation.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Exclamation matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Explorer.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Explorer.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Explorer matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Fabric.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Fabric.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Fabric matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Finagle.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Finagle.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Finagle matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Functions.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Functions.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Functions matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/GRPC.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/GRPC.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`GRPC matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/GitHub.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/GitHub.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`GitHub matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Http.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Http.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Http matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/HttpDelete.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/HttpDelete.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`HttpDelete matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/HttpGet.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/HttpGet.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`HttpGet matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/HttpPatch.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/HttpPatch.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`HttpPatch matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/HttpPost.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/HttpPost.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`HttpPost matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/HttpPut.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/HttpPut.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`HttpPut matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Info.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Info.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Info matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Instances.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Instances.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Instances matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/JVM.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/JVM.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`JVM matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Key.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Key.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Key matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/LinkedIn.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/LinkedIn.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`LinkedIn matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/List.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/List.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`List matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Memory.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Memory.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Memory matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Negation.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Negation.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Negation matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/NoKey.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/NoKey.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`NoKey matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/NoMetrics.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/NoMetrics.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`NoMetrics matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Pause.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Pause.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Pause matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Person.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Person.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Person matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Play.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Play.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Play matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Poll.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Poll.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Poll matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Power.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Power.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Power matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Rows.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Rows.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Rows matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/RunningSmall.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/RunningSmall.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`RunningSmall matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Scale.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Scale.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Scale matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Scatterplot.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Scatterplot.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Scatterplot matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Service.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Service.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Service matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/ServiceInstance.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/ServiceInstance.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`ServiceInstance matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/ServicesWhite.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/ServicesWhite.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`ServicesWhite matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/StarFilled.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/StarFilled.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`StarFilled matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Summary.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Summary.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Summary matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Tape.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Tape.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Tape matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Threads.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Threads.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Threads matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Timer.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Timer.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Timer matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/Twitter.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/Twitter.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Twitter matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Glyphs/__snapshots__/ViewCollapse.test.js.snap
+++ b/src/components/Glyphs/__snapshots__/ViewCollapse.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`ViewCollapse matches snapshot 1`] = `
 <Icon
-  ariaLabelledby="ariaLabelledby"
   backgroundColor="currentColor"
   backgroundOpacity={1}
   backgroundSizeRatio={1}

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -12,10 +12,18 @@ Icon.propTypes = {
     PropTypes.string,
     PropTypes.number
   ]),
-  backgroundStyle: PropTypes.string,
+  backgroundStyle: PropTypes.oneOf([
+    "BackgroundCircleSmall",
+    "BackgroundSquareSmall",
+    "BackgroundTriangleSmall",
+    "BackgroundSquare",
+    "BackgroundSquareBeveled",
+    "BackgroundSquareRounded",
+    "BackgroundSquareRoundedSmooth",
+    "BackgroundTriangle"
+  ]),
   borderColor: PropTypes.string,
   borderOpacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  borderStyle: PropTypes.string,
   borderWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     .isRequired,
   children: PropTypes.element,
@@ -26,7 +34,6 @@ Icon.propTypes = {
 };
 
 Icon.defaultProps = {
-  ariaLabelledby: "ariaLabelledby",
   backgroundColor: "currentColor",
   backgroundOpacity: 1,
   backgroundSizeRatio: 1,
@@ -50,7 +57,6 @@ export default function Icon({
   backgroundStyle,
   borderColor,
   borderOpacity,
-  borderStyle,
   borderWidth,
   children,
   glyphColor,
@@ -61,7 +67,7 @@ export default function Icon({
 }) {
   return (
     <StyledSVG
-      aria-labelledby={ariaLabelledby}
+      aria-labelledby={ariaLabelledby || glyphName}
       focusable="false"
       size={size}
       {...props}
@@ -73,7 +79,7 @@ export default function Icon({
           backgroundOpacity={backgroundOpacity}
           borderColor={borderColor}
           borderOpacity={borderOpacity}
-          borderWidth={parseInt(borderWidth, 10)}
+          borderWidth={parseFloat(borderWidth, 10)}
         />
       )}
       <g title={glyphName} fill={glyphColor}>

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -67,7 +67,7 @@ export default function Icon({
 }) {
   return (
     <StyledSVG
-      aria-labelledby={ariaLabelledby || glyphName}
+      aria-labelledby={ariaLabelledby || title}
       focusable="false"
       size={size}
       {...props}

--- a/src/components/Icon/Icon.stories.js
+++ b/src/components/Icon/Icon.stories.js
@@ -70,7 +70,7 @@ const iconBackgroundNames = [
   "BackgroundSquareRoundedSmooth",
   "BackgroundSquareSmall",
   "BackgroundTriangle",
-  "BackgroundTriangleSmall"
+  "BackgroundTriangleSmall","weird"
 ];
 
 storiesOf("Icons", module)

--- a/src/components/Icon/Icon.stories.js
+++ b/src/components/Icon/Icon.stories.js
@@ -70,7 +70,7 @@ const iconBackgroundNames = [
   "BackgroundSquareRoundedSmooth",
   "BackgroundSquareSmall",
   "BackgroundTriangle",
-  "BackgroundTriangleSmall","weird"
+  "BackgroundTriangleSmall"
 ];
 
 storiesOf("Icons", module)

--- a/src/components/Icon/components/IconBackground/IconBackground.js
+++ b/src/components/Icon/components/IconBackground/IconBackground.js
@@ -60,7 +60,7 @@ export default function IconBackground({
       strokeOpacity={borderOpacity}
       strokeWidth={borderWidth}
     >
-      <IconBackgroundComponent />
+      {IconBackgroundComponent && <IconBackgroundComponent />}
     </g>
   );
 }


### PR DESCRIPTION
Resolves #163 
Resolves #177 

- removed incorrect arialabelledby default prop. This should really be provided by the end user, since it's purpose is to point to the id or classname of a label that describes the element.
- render IconBackground conditionally, in case someone provides an incorrect backgroundStyle. I also added the correct options to proptypes so the end user will get a warning in the console.
- use parseFloat instead of parseInt so that we can pass float values to borderWidth