### PR TITLE
fix: clean up styles, responsiveness, & hide delimiter when there is only one item

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -5,29 +5,21 @@ import styled from "styled-components";
 export const Breadcrumb = styled.li`
   flex: 0 0 auto;
   display: flex;
-  align-items: center;
   &:before {
     content: ">";
     transform: scaleX(0.5);
     display: flex;
-    opacity: 0.5;
+    opacity: ${props => (props.hideDelimiter ? 0 : 0.5)};
     padding: 0 4px;
   }
   a {
-    display: flex;
-    max-width: 100%;
     white-space: nowrap;
     text-overflow: ellipsis;
-    padding: 8px 0;
     color: inherit;
-    text-decoration: none;
   }
   &:first-child {
     &:before {
       content: none;
-    }
-    a {
-      padding-left: 16px;
     }
   }
 `;

--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -3,12 +3,14 @@ import React from "react";
 import styled from "styled-components";
 
 export const Breadcrumb = styled.li`
-  flex: 0 0 auto;
+  flex: 0 1 100%;
   display: flex;
+  max-width: fit-content;
+  overflow: hidden;
+
   &:before {
     content: ">";
     transform: scaleX(0.5);
-    display: flex;
     opacity: ${props => (props.hideDelimiter ? 0 : 0.5)};
     padding: 0 4px;
   }

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -54,7 +54,13 @@ class Breadcrumbs extends React.Component {
 
   renderExpanded = crumbs => {
     return crumbs.map((item, i) => {
-      return <BreadcrumbItem key={i} item={item} />;
+      return (
+        <BreadcrumbItem
+          key={i}
+          item={item}
+          hideDelimiter={crumbs.length === 1}
+        />
+      );
     });
   };
 

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.js
@@ -6,7 +6,15 @@ import { withInfo } from "@storybook/addon-info";
 
 const stories = storiesOf("Breadcrumbs", module);
 const label = "Breadcrumbs";
-const defaultCrumbs = ["Home", "View", "Data", "Graphs"];
+const defaultCrumbs = [
+  "Home",
+  "View",
+  "Data",
+  "Graphs",
+  "Things",
+  "stuff",
+  "garbage"
+];
 const separator = ",";
 const breadCrumbsInfo =
   "A React component that allows users to know their location. Use <Breadcrumbs> and pass it an array of crumbs and an optional maxItems prop.  If there are more children than the maximum, it will render a collapsed view.";
@@ -19,7 +27,11 @@ stories.add(
   "simple breadcrumbs",
   withInfo(breadCrumbsInfo)(() => {
     crumbs = array(label, defaultCrumbs, separator);
-    return <Breadcrumbs crumbs={crumbs} />;
+    return (
+      <div style={{ backgroundColor: "black", width: "300px" }}>
+        <Breadcrumbs crumbs={crumbs} style={{ color: "white" }} />;
+      </div>
+    );
   })
 );
 

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -9,10 +9,6 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c1:before {
@@ -29,25 +25,13 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
 }
 
 .c1 a {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  max-width: 100%;
   white-space: nowrap;
   text-overflow: ellipsis;
-  padding: 8px 0;
   color: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c1:first-child:before {
   content: none;
-}
-
-.c1:first-child a {
-  padding-left: 16px;
 }
 
 .c0 {
@@ -104,10 +88,6 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c1:before {
@@ -124,25 +104,13 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
 }
 
 .c1 a {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  max-width: 100%;
   white-space: nowrap;
   text-overflow: ellipsis;
-  padding: 8px 0;
   color: inherit;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c1:first-child:before {
   content: none;
-}
-
-.c1:first-child a {
-  padding-left: 16px;
 }
 
 .c0 {

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -2,13 +2,17 @@
 
 exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
 .c1 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+  overflow: hidden;
 }
 
 .c1:before {
@@ -16,10 +20,6 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
   -webkit-transform: scaleX(0.5);
   -ms-transform: scaleX(0.5);
   transform: scaleX(0.5);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   opacity: 0.5;
   padding: 0 4px;
 }
@@ -81,13 +81,17 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
 
 exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
 .c1 {
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
+  -webkit-flex: 0 1 100%;
+  -ms-flex: 0 1 100%;
+  flex: 0 1 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+  overflow: hidden;
 }
 
 .c1:before {
@@ -95,10 +99,6 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
   -webkit-transform: scaleX(0.5);
   -ms-transform: scaleX(0.5);
   transform: scaleX(0.5);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   opacity: 0.5;
   padding: 0 4px;
 }


### PR DESCRIPTION
Resolves #186 
- cleaned up styles
- made the crumbs responsive, so they will fit the parent container
- added an internal prop, `hideDelimiter`, that hides the > when there is only one item