### PR TITLE
fix: cleanup NavCard and NavCardGroup styles

### DIFF
--- a/src/components/LayoutSection/LayoutSection.stories.js
+++ b/src/components/LayoutSection/LayoutSection.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { text, boolean, withKnobs } from "@storybook/addon-knobs";
+import { text, withKnobs } from "@storybook/addon-knobs";
 import { withInfo } from "@storybook/addon-info";
 
 import LayoutSection from "./LayoutSection";

--- a/src/components/NavCard/NavCard.stories.js
+++ b/src/components/NavCard/NavCard.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { storiesOf } from "@storybook/react";
-import { text, object, array } from "@storybook/addon-knobs/react";
+import { text, object } from "@storybook/addon-knobs/react";
 
 import NavCard from "components/NavCard";
 

--- a/src/components/NavCard/components/NavCardWrapper.js
+++ b/src/components/NavCard/components/NavCardWrapper.js
@@ -19,7 +19,6 @@ const NavCardWrapper = styled.div`
   font-weight: ${FONT_WEIGHT_REGULAR};
   font-family: ${FONT_STACK_BASE};
   flex: 1 1 ${TAB_WIDTH_BASE};
-  overflow: hidden;
   padding: ${spacingScale(0.5)};
   position: relative;
   transition: all 0.15s ease;

--- a/src/components/NavCard/components/NavCardWrapper.js
+++ b/src/components/NavCard/components/NavCardWrapper.js
@@ -41,8 +41,8 @@ const NavCardWrapper = styled.div`
     border: 2px solid ${COLOR_HIGHLIGHT};
     opacity: 0;
   }
-  :focus,
-  :hover {
+  &:focus,
+  &:hover {
     background-color: ${darken(0.06, TAB_BASE_COLOR)};
   }
 `;

--- a/src/components/NavCard/components/NavCardWrapper.js
+++ b/src/components/NavCard/components/NavCardWrapper.js
@@ -1,4 +1,6 @@
 import styled from "styled-components";
+import { darken } from "polished";
+
 import { spacingScale, contrastColor } from "style/styleFunctions";
 import {
   COLOR_CONTENT_BACKGROUND,
@@ -7,7 +9,7 @@ import {
   FONT_STACK_BASE,
   COLOR_HIGHLIGHT
 } from "style/styleVariables";
-import { darken } from "polished";
+
 const TAB_BASE_COLOR = contrastColor(COLOR_CONTENT_BACKGROUND, 0.8);
 const TAB_WIDTH_BASE = "1%";
 

--- a/src/components/NavCard/components/NavCardWrapper.js
+++ b/src/components/NavCard/components/NavCardWrapper.js
@@ -1,15 +1,13 @@
 import styled from "styled-components";
-import { darken } from "polished";
-
 import { spacingScale, contrastColor } from "style/styleFunctions";
 import {
-  COLOR_HIGHLIGHT,
   COLOR_CONTENT_BACKGROUND,
   FONT_WEIGHT_REGULAR,
   BORDER_RADIUS_BASE,
-  FONT_STACK_BASE
+  FONT_STACK_BASE,
+  COLOR_HIGHLIGHT
 } from "style/styleVariables";
-
+import { darken } from "polished";
 const TAB_BASE_COLOR = contrastColor(COLOR_CONTENT_BACKGROUND, 0.8);
 const TAB_WIDTH_BASE = "1%";
 
@@ -19,7 +17,6 @@ const NavCardWrapper = styled.div`
   font-weight: ${FONT_WEIGHT_REGULAR};
   font-family: ${FONT_STACK_BASE};
   flex: 1 1 ${TAB_WIDTH_BASE};
-  margin: ${spacingScale(0.25)};
   overflow: hidden;
   padding: ${spacingScale(0.5)};
   position: relative;
@@ -30,7 +27,7 @@ const NavCardWrapper = styled.div`
   flex-direction: column;
   align-items: stretch;
   min-height: ${spacingScale(10)};
-
+  margin: ${spacingScale(0.25)};
   &:after {
     content: "";
     position: absolute;
@@ -42,18 +39,8 @@ const NavCardWrapper = styled.div`
     border: 2px solid ${COLOR_HIGHLIGHT};
     opacity: 0;
   }
-
-  &.active,
-  &.active:hover {
-    background-color: ${darken(0.1, TAB_BASE_COLOR)};
-
-    &:after {
-      opacity: 1;
-    }
-  }
-
-  &:focus,
-  &:hover {
+  :focus,
+  :hover {
     background-color: ${darken(0.06, TAB_BASE_COLOR)};
   }
 `;

--- a/src/components/NavCard/components/__snapshots__/NavCardWrapper.test.js.snap
+++ b/src/components/NavCard/components/__snapshots__/NavCardWrapper.test.js.snap
@@ -6,7 +6,6 @@ exports[`NavCardWrapper matches snapshot 1`] = `
   -webkit-flex: 1 1 1%;
   -ms-flex: 1 1 1%;
   flex: 1 1 1%;
-  margin: 2px;
   overflow: hidden;
   padding: 4px;
   position: relative;
@@ -26,6 +25,7 @@ exports[`NavCardWrapper matches snapshot 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   min-height: 80px;
+  margin: 2px;
 }
 
 .c0:after {
@@ -38,16 +38,6 @@ exports[`NavCardWrapper matches snapshot 1`] = `
   border-radius: 4px;
   border: 2px solid #0aab2a;
   opacity: 0;
-}
-
-.c0.active,
-.c0.active:hover {
-  background-color: #181818;
-}
-
-.c0.active:after,
-.c0.active:hover:after {
-  opacity: 1;
 }
 
 .c0:focus,

--- a/src/components/NavCard/components/__snapshots__/NavCardWrapper.test.js.snap
+++ b/src/components/NavCard/components/__snapshots__/NavCardWrapper.test.js.snap
@@ -6,7 +6,6 @@ exports[`NavCardWrapper matches snapshot 1`] = `
   -webkit-flex: 1 1 1%;
   -ms-flex: 1 1 1%;
   flex: 1 1 1%;
-  overflow: hidden;
   padding: 4px;
   position: relative;
   -webkit-transition: all 0.15s ease;

--- a/src/components/NavCardGroup/NavCardGroup.js
+++ b/src/components/NavCardGroup/NavCardGroup.js
@@ -1,11 +1,12 @@
+import styled from "styled-components";
+import { darken } from "polished";
+
 import {
   COLOR_WHITE,
   COLOR_BLACK,
   COLOR_CONTENT_BACKGROUND
 } from "style/styleVariables";
-import styled from "styled-components";
 import { contrastColor, spacingScale } from "style/styleFunctions";
-import { darken } from "polished";
 
 const TAB_BASE_COLOR = contrastColor(COLOR_CONTENT_BACKGROUND, 0.8);
 const COLOR_TAB_BACKGROUND_BASE = contrastColor(COLOR_WHITE, 0.175);

--- a/src/components/NavCardGroup/NavCardGroup.js
+++ b/src/components/NavCardGroup/NavCardGroup.js
@@ -31,6 +31,17 @@ const NavCardGroup = styled.nav`
     text-decoration: none;
     /* When the link element is active, make NavCard's green border pseudo-element
        visible and style the NavCard background color. */
+    &:active,
+    &:active:hover,
+    &.active,
+    &.active:hover {
+      > div[class*="NavCard"] {
+        &:after {
+          opacity: 1;
+        }
+        background-color: ${darken(0.1, TAB_BASE_COLOR)};
+      }
+    }
   }
 `;
 

--- a/src/components/NavCardGroup/NavCardGroup.js
+++ b/src/components/NavCardGroup/NavCardGroup.js
@@ -17,7 +17,6 @@ const NavCardGroup = styled.nav`
   flex-flow: row wrap;
   color: ${contrastColor(COLOR_TAB_BACKGROUND_BASE)};
   padding: ${spacingScale(0.25)};
-  overflow: hidden;
   position: relative;
   background-color: ${COLOR_BLACK};
   /* Since the end-user will wrap NavCard with a link element,
@@ -36,7 +35,7 @@ const NavCardGroup = styled.nav`
     &:active:hover,
     &.active,
     &.active:hover {
-      > div[class*="NavCard"] {
+      div[class*="NavCardWrapper"] {
         &:after {
           opacity: 1;
         }

--- a/src/components/NavCardGroup/NavCardGroup.js
+++ b/src/components/NavCardGroup/NavCardGroup.js
@@ -1,8 +1,15 @@
-import { COLOR_WHITE, COLOR_BLACK } from "style/styleVariables";
+import {
+  COLOR_WHITE,
+  COLOR_BLACK,
+  COLOR_CONTENT_BACKGROUND
+} from "style/styleVariables";
 import styled from "styled-components";
 import { contrastColor, spacingScale } from "style/styleFunctions";
+import { darken } from "polished";
 
+const TAB_BASE_COLOR = contrastColor(COLOR_CONTENT_BACKGROUND, 0.8);
 const COLOR_TAB_BACKGROUND_BASE = contrastColor(COLOR_WHITE, 0.175);
+const TAB_WIDTH_BASE = "1%";
 
 const NavCardGroup = styled.nav`
   display: flex;
@@ -12,6 +19,19 @@ const NavCardGroup = styled.nav`
   overflow: hidden;
   position: relative;
   background-color: ${COLOR_BLACK};
+  /* Since the end-user will wrap NavCard with a link element,
+     we need to style those child elements here */
+  > * {
+    flex: 1 1 ${TAB_WIDTH_BASE};
+    display: flex;
+    position: relative;
+    align-items: stretch;
+    min-height: ${spacingScale(10)};
+    position: relative;
+    text-decoration: none;
+    /* When the link element is active, make NavCard's green border pseudo-element
+       visible and style the NavCard background color. */
+  }
 `;
 
 export default NavCardGroup;

--- a/src/components/NavCardGroup/__snapshots__/NavCardGroup.test.js.snap
+++ b/src/components/NavCardGroup/__snapshots__/NavCardGroup.test.js.snap
@@ -16,6 +16,39 @@ exports[`NavCardGroup matches snapshot 1`] = `
   background-color: #000;
 }
 
+.c0 > * {
+  -webkit-flex: 1 1 1%;
+  -ms-flex: 1 1 1%;
+  flex: 1 1 1%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  min-height: 80px;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 > *:active > div[class*="NavCard"],
+.c0 > *:active:hover > div[class*="NavCard"],
+.c0 > *.active > div[class*="NavCard"],
+.c0 > *.active:hover > div[class*="NavCard"] {
+  background-color: #181818;
+}
+
+.c0 > *:active > div[class*="NavCard"]:after,
+.c0 > *:active:hover > div[class*="NavCard"]:after,
+.c0 > *.active > div[class*="NavCard"]:after,
+.c0 > *.active:hover > div[class*="NavCard"]:after {
+  opacity: 1;
+}
+
 <nav
   className="c0"
 />

--- a/src/components/NavCardGroup/__snapshots__/NavCardGroup.test.js.snap
+++ b/src/components/NavCardGroup/__snapshots__/NavCardGroup.test.js.snap
@@ -11,7 +11,6 @@ exports[`NavCardGroup matches snapshot 1`] = `
   flex-flow: row wrap;
   color: rgba(NaN,NaN,NaN,NaN);
   padding: 2px;
-  overflow: hidden;
   position: relative;
   background-color: #000;
 }
@@ -35,17 +34,17 @@ exports[`NavCardGroup matches snapshot 1`] = `
   text-decoration: none;
 }
 
-.c0 > *:active > div[class*="NavCard"],
-.c0 > *:active:hover > div[class*="NavCard"],
-.c0 > *.active > div[class*="NavCard"],
-.c0 > *.active:hover > div[class*="NavCard"] {
+.c0 > *:active div[class*="NavCardWrapper"],
+.c0 > *:active:hover div[class*="NavCardWrapper"],
+.c0 > *.active div[class*="NavCardWrapper"],
+.c0 > *.active:hover div[class*="NavCardWrapper"] {
   background-color: #181818;
 }
 
-.c0 > *:active > div[class*="NavCard"]:after,
-.c0 > *:active:hover > div[class*="NavCard"]:after,
-.c0 > *.active > div[class*="NavCard"]:after,
-.c0 > *.active:hover > div[class*="NavCard"]:after {
+.c0 > *:active div[class*="NavCardWrapper"]:after,
+.c0 > *:active:hover div[class*="NavCardWrapper"]:after,
+.c0 > *.active div[class*="NavCardWrapper"]:after,
+.c0 > *.active:hover div[class*="NavCardWrapper"]:after {
   opacity: 1;
 }
 

--- a/src/components/Readout/Readout.stories.js
+++ b/src/components/Readout/Readout.stories.js
@@ -14,18 +14,6 @@ const mockReadoutItem = [
     value: "30000%"
   }
 ];
-const mockReadoutFewItems = [
-  {
-    icon: () => <Summary size={"24px"} />,
-    title: "Avg. Response Time",
-    value: "57.838%"
-  },
-  {
-    icon: () => <Summary size={"24px"} />,
-    title: "Error Rate",
-    value: "0.0012%"
-  }
-];
 
 const mockReadoutManyItems = [
   {

--- a/src/components/Readout/components/ReadoutItem/ReadoutItem.test.js
+++ b/src/components/Readout/components/ReadoutItem/ReadoutItem.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { shallow, render } from "enzyme";
+import { shallow } from "enzyme";
 
 import ReadoutItem from "./ReadoutItem";
 import { Summary } from "../../../";


### PR DESCRIPTION
This was a little tricky, because we're expecting NavCard to be wrapped in a link element by the end user, so NavCard is no longer the direct child of NavCardGroup. That means we need to style the link elements from NavCardGroup. I tried to add comments to clarify the css.

