### PR TITLE
fix: breadcrumb responsiveness

### DIFF
--- a/src/components/AppHeader/AppHeader.stories.js
+++ b/src/components/AppHeader/AppHeader.stories.js
@@ -34,24 +34,22 @@ const toolbarItems = () => {
       }}
     >
       <Breadcrumbs crumbs={breadcrumbs} />
-      <div style={{ display: "flex" }}>
-        <span>1.1.6</span>
-        <ToolbarButtonGroup style={{ paddingRight: 0, flex: "0 0 auto" }}>
-          <Button
-            outline="none"
-            size="xs"
-            label=""
-            type="info"
-            style={{
-              border: "none",
-              backgroundColor: "white",
-              color: "black"
-            }}
-          >
-            <Cog size={"24px"} />
-          </Button>
-        </ToolbarButtonGroup>
-      </div>
+      <span>1.1.6</span>
+      <ToolbarButtonGroup style={{ paddingRight: 0 }}>
+        <Button
+          outline="none"
+          size="xs"
+          label=""
+          type="info"
+          style={{
+            border: "none",
+            backgroundColor: "white",
+            color: "black"
+          }}
+        >
+          <Cog size={"24px"} />
+        </Button>
+      </ToolbarButtonGroup>
     </div>
   );
 };

--- a/src/components/AppHeader/AppHeader.stories.js
+++ b/src/components/AppHeader/AppHeader.stories.js
@@ -30,7 +30,8 @@ const toolbarItems = () => {
       style={{
         display: "flex",
         width: "100%",
-        alignItems: "center"
+        alignItems: "center",
+        flex: "1 1 auto"
       }}
     >
       <Breadcrumbs crumbs={breadcrumbs} />

--- a/src/components/AppHeader/AppHeader.stories.js
+++ b/src/components/AppHeader/AppHeader.stories.js
@@ -13,7 +13,12 @@ const bannerExtras = [
   }
 ];
 
-const breadcrumbs = ["Fabric", "Instances", "Routes"];
+const breadcrumbs = [
+  <a href="#">Fabric</a>,
+  <a href="#">Instances</a>,
+  <a href="#">Routes</a>,
+  <a href="#">Grace Hopper Battleship Service</a>
+];
 
 const ToolbarButtonGroup = ButtonGroup.extend`
   padding: ${spacingScale(0)} ${spacingScale(1)};
@@ -29,22 +34,24 @@ const toolbarItems = () => {
       }}
     >
       <Breadcrumbs crumbs={breadcrumbs} />
-      <span>1.1.6</span>
-      <ToolbarButtonGroup style={{ paddingRight: 0 }}>
-        <Button
-          outline="none"
-          size="xs"
-          label=""
-          type="info"
-          style={{
-            border: "none",
-            backgroundColor: "white",
-            color: "black"
-          }}
-        >
-          <Cog size={"24px"} />
-        </Button>
-      </ToolbarButtonGroup>
+      <div style={{ display: "flex" }}>
+        <span>1.1.6</span>
+        <ToolbarButtonGroup style={{ paddingRight: 0, flex: "0 0 auto" }}>
+          <Button
+            outline="none"
+            size="xs"
+            label=""
+            type="info"
+            style={{
+              border: "none",
+              backgroundColor: "white",
+              color: "black"
+            }}
+          >
+            <Cog size={"24px"} />
+          </Button>
+        </ToolbarButtonGroup>
+      </div>
     </div>
   );
 };

--- a/src/components/AppHeader/components/HeaderWrapper.js
+++ b/src/components/AppHeader/components/HeaderWrapper.js
@@ -25,6 +25,7 @@ const HeaderWrapper = styled.div`
   background-size: 100% 100%, 120% auto;
   background-position: center center, left center;
   background-repeat: no-repeat;
+  overflow: hidden;
 `;
 
 export default HeaderWrapper;

--- a/src/components/AppHeader/components/__snapshots__/HeaderWrapper.test.js.snap
+++ b/src/components/AppHeader/components/__snapshots__/HeaderWrapper.test.js.snap
@@ -23,6 +23,7 @@ exports[`HeaderWrapper matches snapshot 1`] = `
   background-size: 100% 100%,120% auto;
   background-position: center center,left center;
   background-repeat: no-repeat;
+  overflow: hidden;
 }
 
 <div

--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -3,10 +3,18 @@ import React from "react";
 import styled from "styled-components";
 
 export const Breadcrumb = styled.li`
-  flex: 0 1 100%;
+  flex: 0 1 auto;
   display: flex;
-  max-width: fit-content;
   overflow: hidden;
+  white-space: nowrap;
+  max-width: fit-content;
+
+  @media (max-width: 800px) {
+    max-width: calc(25vw);
+  }
+  @media (max-width: 567px) {
+    max-width: calc(11.1111vw);
+  }
 
   &:before {
     content: ">";
@@ -14,7 +22,7 @@ export const Breadcrumb = styled.li`
     opacity: ${props => (props.hideDelimiter ? 0 : 0.5)};
     padding: 0 4px;
   }
-  a {
+  > * {
     white-space: nowrap;
     text-overflow: ellipsis;
     color: inherit;

--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -6,14 +6,7 @@ export const Breadcrumb = styled.li`
   flex: 0 1 auto;
   display: flex;
   overflow: hidden;
-  white-space: nowrap;
-
-  @media (max-width: 800px) {
-    max-width: calc(25vw);
-  }
-  @media (max-width: 567px) {
-    max-width: calc(11.1111vw);
-  }
+  max-width: 100%;
 
   &:before {
     content: ">";
@@ -21,11 +14,12 @@ export const Breadcrumb = styled.li`
     opacity: ${props => (props.hideDelimiter ? 0 : 0.5)};
     padding: 0 4px;
   }
+
   > * {
-    white-space: nowrap;
     text-overflow: ellipsis;
     color: inherit;
   }
+
   &:first-child {
     &:before {
       content: none;

--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -7,7 +7,6 @@ export const Breadcrumb = styled.li`
   display: flex;
   overflow: hidden;
   white-space: nowrap;
-  max-width: fit-content;
 
   @media (max-width: 800px) {
     max-width: calc(25vw);

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -13,6 +13,7 @@ export const BreadcrumbsContainer = styled.ol`
   font-family: ${FONT_STACK_BASE};
   height: inherit;
   align-items: stretch;
+  flex-wrap: wrap;
 `;
 
 class Breadcrumbs extends React.Component {

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -31,9 +31,13 @@ class Breadcrumbs extends React.Component {
   }
 
   updateView = props => {
-    const { crumbs, maxItems } = props;
+    const { crumbs, maxItems, collapse } = props;
     const childrenLen = crumbs.length;
-    maxItems < childrenLen ? this.collapse() : this.expand();
+    if (collapse || maxItems < childrenLen) {
+      this.collapse();
+    } else {
+      this.expand();
+    }
   };
 
   collapse = () => this.setState({ isCollapsed: true });
@@ -81,10 +85,12 @@ class Breadcrumbs extends React.Component {
 export default Breadcrumbs;
 
 Breadcrumbs.defaultProps = {
-  maxItems: 10
+  maxItems: 10,
+  collapse: false
 };
 
 Breadcrumbs.propTypes = {
+  collapse: PropTypes.bool,
   crumbs: PropTypes.array.isRequired,
   maxItems: PropTypes.number
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.js
@@ -1,33 +1,43 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { withKnobs, array, number } from "@storybook/addon-knobs/react";
+import {
+  withKnobs,
+  array,
+  number,
+  boolean
+} from "@storybook/addon-knobs/react";
 import Breadcrumbs from "./Breadcrumbs";
 import { withInfo } from "@storybook/addon-info";
 
 const stories = storiesOf("Breadcrumbs", module);
-const label = "Breadcrumbs";
 const defaultCrumbs = ["Home", "View", "Data", "Graphs"];
-const separator = ",";
 const breadCrumbsInfo =
   "A React component that allows users to know their location. Use <Breadcrumbs> and pass it an array of crumbs and an optional maxItems prop.  If there are more children than the maximum, it will render a collapsed view.";
-
-let crumbs, maxItems;
 
 stories.addDecorator(withKnobs);
 
 stories.add(
   "simple breadcrumbs",
   withInfo(breadCrumbsInfo)(() => {
-    crumbs = array(label, defaultCrumbs, separator);
-    return <Breadcrumbs crumbs={crumbs} />;
+    return (
+      <Breadcrumbs
+        crumbs={array("crumbs", defaultCrumbs)}
+        maxItems={number("maxItems", 10)}
+        collapse={boolean("collapse", false)}
+      />
+    );
   })
 );
 
 stories.add(
   "truncated breadcrumbs",
   withInfo(breadCrumbsInfo)(() => {
-    crumbs = array(label, defaultCrumbs, separator);
-    maxItems = number("Max Items", 3);
-    return <Breadcrumbs crumbs={crumbs} maxItems={maxItems} />;
+    return (
+      <Breadcrumbs
+        crumbs={array("crumbs", defaultCrumbs)}
+        maxItems={number("maxItems", 3)}
+        collapse={boolean("collapse", false)}
+      />
+    );
   })
 );

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.js
@@ -6,15 +6,7 @@ import { withInfo } from "@storybook/addon-info";
 
 const stories = storiesOf("Breadcrumbs", module);
 const label = "Breadcrumbs";
-const defaultCrumbs = [
-  "Home",
-  "View",
-  "Data",
-  "Graphs",
-  "Things",
-  "stuff",
-  "garbage"
-];
+const defaultCrumbs = ["Home", "View", "Data", "Graphs"];
 const separator = ",";
 const breadCrumbsInfo =
   "A React component that allows users to know their location. Use <Breadcrumbs> and pass it an array of crumbs and an optional maxItems prop.  If there are more children than the maximum, it will render a collapsed view.";
@@ -27,11 +19,7 @@ stories.add(
   "simple breadcrumbs",
   withInfo(breadCrumbsInfo)(() => {
     crumbs = array(label, defaultCrumbs, separator);
-    return (
-      <div style={{ backgroundColor: "black", width: "300px" }}>
-        <Breadcrumbs crumbs={crumbs} style={{ color: "white" }} />;
-      </div>
-    );
+    return <Breadcrumbs crumbs={crumbs} />;
   })
 );
 

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -2,17 +2,15 @@
 
 exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
 .c1 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: -webkit-fit-content;
-  max-width: -moz-fit-content;
-  max-width: fit-content;
   overflow: hidden;
+  white-space: nowrap;
 }
 
 .c1:before {
@@ -24,7 +22,7 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
   padding: 0 4px;
 }
 
-.c1 a {
+.c1 > * {
   white-space: nowrap;
   text-overflow: ellipsis;
   color: inherit;
@@ -53,6 +51,18 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
+}
+
+@media (max-width:800px) {
+  .c1 {
+    max-width: calc(25vw);
+  }
+}
+
+@media (max-width:567px) {
+  .c1 {
+    max-width: calc(11.1111vw);
+  }
 }
 
 <ol
@@ -81,17 +91,15 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
 
 exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
 .c1 {
-  -webkit-flex: 0 1 100%;
-  -ms-flex: 0 1 100%;
-  flex: 0 1 100%;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: -webkit-fit-content;
-  max-width: -moz-fit-content;
-  max-width: fit-content;
   overflow: hidden;
+  white-space: nowrap;
 }
 
 .c1:before {
@@ -103,7 +111,7 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
   padding: 0 4px;
 }
 
-.c1 a {
+.c1 > * {
   white-space: nowrap;
   text-overflow: ellipsis;
   color: inherit;
@@ -132,6 +140,18 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
+}
+
+@media (max-width:800px) {
+  .c1 {
+    max-width: calc(25vw);
+  }
+}
+
+@media (max-width:567px) {
+  .c1 {
+    max-width: calc(11.1111vw);
+  }
 }
 
 <ol

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -10,7 +10,7 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
   display: -ms-flexbox;
   display: flex;
   overflow: hidden;
-  white-space: nowrap;
+  max-width: 100%;
 }
 
 .c1:before {
@@ -23,7 +23,6 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
 }
 
 .c1 > * {
-  white-space: nowrap;
   text-overflow: ellipsis;
   color: inherit;
 }
@@ -51,18 +50,9 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-@media (max-width:800px) {
-  .c1 {
-    max-width: calc(25vw);
-  }
-}
-
-@media (max-width:567px) {
-  .c1 {
-    max-width: calc(11.1111vw);
-  }
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 <ol
@@ -99,7 +89,7 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
   display: -ms-flexbox;
   display: flex;
   overflow: hidden;
-  white-space: nowrap;
+  max-width: 100%;
 }
 
 .c1:before {
@@ -112,7 +102,6 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
 }
 
 .c1 > * {
-  white-space: nowrap;
   text-overflow: ellipsis;
   color: inherit;
 }
@@ -140,18 +129,9 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-@media (max-width:800px) {
-  .c1 {
-    max-width: calc(25vw);
-  }
-}
-
-@media (max-width:567px) {
-  .c1 {
-    max-width: calc(11.1111vw);
-  }
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 <ol


### PR DESCRIPTION
Resolves #222 

- added a `collapse` prop for finer control
- added `flex-wrap: wrap;` to the Breadcrumb wrapper so that items flow onto a new line
- cleaned up breadcrumb and appheader stories