### PR TITLE
fix: remove breadcrumbs from AppHeader story

### DIFF
--- a/src/components/AppHeader/AppHeader.stories.js
+++ b/src/components/AppHeader/AppHeader.stories.js
@@ -75,7 +75,6 @@ storiesOf("App Header", module)
         <AppHeader
           title={text("title", "GM UI App Header")}
           extras={object("extras", bannerExtras)}
-          breadcrumbs={object("breadcrumbs", breadcrumbs)}
           toolbarItems={toolbarItems}
         />
       );


### PR DESCRIPTION
The breadcrumbs prop is obsolete now that we pass the toolbarItems render prop