### PR TITLE
feat: add accentColor prop to table

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -7,6 +7,7 @@ import TableRow from "./components/TableRow";
 import TableColumn from "./components/TableColumn";
 
 import { columnItemShape, dataItemShape } from "./types";
+import { COLOR_BRAND_PRIMARY } from "style/styleVariables";
 
 export default function Table({
   columns = [],
@@ -15,6 +16,7 @@ export default function Table({
   onSort,
   selectedRows = [],
   sortDataIndex,
+  accentColor = COLOR_BRAND_PRIMARY,
   ...props
 }) {
   return (
@@ -33,6 +35,7 @@ export default function Table({
       <tbody>
         {data.map((item, rowIndex) => (
           <TableRow
+            accentColor={accentColor}
             data={item}
             key={item.key}
             columns={columns}
@@ -49,6 +52,7 @@ export default function Table({
 }
 
 Table.propTypes = {
+  accentColor: PropTypes.string,
   columns: PropTypes.arrayOf(columnItemShape), // An array of objects used to label and size columns
   data: PropTypes.arrayOf(dataItemShape), // An array of objects to populate the rows
   onCellClick: PropTypes.func, // A function called when a user clicks a cell. Passes the row data, row index, and column dataIndex.

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -7,7 +7,6 @@ import TableRow from "./components/TableRow";
 import TableColumn from "./components/TableColumn";
 
 import { columnItemShape, dataItemShape } from "./types";
-import { COLOR_BRAND_PRIMARY } from "style/styleVariables";
 
 export default function Table({
   columns = [],
@@ -16,7 +15,7 @@ export default function Table({
   onSort,
   selectedRows = [],
   sortDataIndex,
-  accentColor = COLOR_BRAND_PRIMARY,
+  accentColor,
   ...props
 }) {
   return (

--- a/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/src/components/Table/__snapshots__/Table.test.js.snap
@@ -56,6 +56,7 @@ exports[`Table matches snapshot 1`] = `
   />
   <tbody>
     <TableRow
+      accentColor="#0aab2a"
       columns={
         Array [
           Object {
@@ -102,6 +103,7 @@ exports[`Table matches snapshot 1`] = `
       rowIndex={0}
     />
     <TableRow
+      accentColor="#0aab2a"
       columns={
         Array [
           Object {
@@ -148,6 +150,7 @@ exports[`Table matches snapshot 1`] = `
       rowIndex={1}
     />
     <TableRow
+      accentColor="#0aab2a"
       columns={
         Array [
           Object {

--- a/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/src/components/Table/__snapshots__/Table.test.js.snap
@@ -56,7 +56,6 @@ exports[`Table matches snapshot 1`] = `
   />
   <tbody>
     <TableRow
-      accentColor="#0aab2a"
       columns={
         Array [
           Object {
@@ -103,7 +102,6 @@ exports[`Table matches snapshot 1`] = `
       rowIndex={0}
     />
     <TableRow
-      accentColor="#0aab2a"
       columns={
         Array [
           Object {
@@ -150,7 +148,6 @@ exports[`Table matches snapshot 1`] = `
       rowIndex={1}
     />
     <TableRow
-      accentColor="#0aab2a"
       columns={
         Array [
           Object {

--- a/src/components/Table/components/TableRow.js
+++ b/src/components/Table/components/TableRow.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import { lighten, transparentize } from "polished";
 
-import { COLOR_GREY } from "style/styleVariables";
+import { COLOR_GREY, COLOR_BRAND_PRIMARY } from "style/styleVariables";
 import { columnItemShape, dataItemShape } from "../types";
 
 import TableCell from "./TableCell";
@@ -34,7 +34,7 @@ function TableRow({
   isSelected,
   onCellClick,
   rowIndex,
-  accentColor
+  accentColor = COLOR_BRAND_PRIMARY
 }) {
   return (
     <TableRowElement isSelected={isSelected} accentColor={accentColor}>
@@ -59,6 +59,7 @@ function TableRow({
 }
 
 TableRow.propTypes = {
+  accentColor: PropTypes.string,
   columns: PropTypes.arrayOf(columnItemShape),
   data: dataItemShape,
   isRowSelected: PropTypes.bool,

--- a/src/components/Table/components/TableRow.js
+++ b/src/components/Table/components/TableRow.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import { lighten, transparentize } from "polished";
 
-import { COLOR_GREY, COLOR_BRAND_PRIMARY } from "style/styleVariables";
+import { COLOR_GREY } from "style/styleVariables";
 import { columnItemShape, dataItemShape } from "../types";
 
 import TableCell from "./TableCell";
@@ -17,7 +17,7 @@ const TableRowElement = styled.tr`
   ${props =>
     props.isSelected &&
     css`
-      background-color: ${transparentize(0.85, COLOR_BRAND_PRIMARY)};
+      background-color: ${transparentize(0.85, props.accentColor)};
       &,
       & + &,
       & + tr {
@@ -28,9 +28,16 @@ const TableRowElement = styled.tr`
 
 TableRowElement.displayName = "TableRowElement";
 
-function TableRow({ data, columns, isSelected, onCellClick, rowIndex }) {
+function TableRow({
+  data,
+  columns,
+  isSelected,
+  onCellClick,
+  rowIndex,
+  accentColor
+}) {
   return (
-    <TableRowElement isSelected={isSelected}>
+    <TableRowElement isSelected={isSelected} accentColor={accentColor}>
       {/* Because the `columns` array determines the desired column order, 
         we need to map through it and use the dataIndex property to pick out 
         the appropriate data for that column */}

--- a/src/components/Table/components/tests/__snapshots__/TableRow.test.js.snap
+++ b/src/components/Table/components/tests/__snapshots__/TableRow.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableRow matches snapshot 1`] = `
-<TableRowElement>
+<TableRowElement
+  accentColor="#0aab2a"
+>
   <TableCell
     data-column="name"
     key="name|2"


### PR DESCRIPTION
Since the library is moving away from being a product-only tool, we should offer a color prop so that the consuming app can specify it's own brand color. Defaults to decipher brand color.