### PR TITLE
fix: add styleSelectedRow prop

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -16,6 +16,7 @@ export default function Table({
   selectedRows = [],
   sortDataIndex,
   accentColor,
+  selectedRowStyle,
   ...props
 }) {
   return (
@@ -40,6 +41,7 @@ export default function Table({
             columns={columns}
             onCellClick={onCellClick}
             rowIndex={rowIndex}
+            selectedRowStyle={selectedRowStyle}
             isSelected={selectedRows.some(
               selectedRow => selectedRow === rowIndex
             )}
@@ -56,6 +58,7 @@ Table.propTypes = {
   data: PropTypes.arrayOf(dataItemShape), // An array of objects to populate the rows
   onCellClick: PropTypes.func, // A function called when a user clicks a cell. Passes the row data, row index, and column dataIndex.
   onSort: PropTypes.func, // A function called when a user sorts a column. Passes the dataIndex of the column being sorted.
+  selectedRowStyle: PropTypes.object, // A style object to pass to a row when selected
   selectedRows: PropTypes.arrayOf(PropTypes.number), // An array of indices of the currently selected rows
   sortDataIndex: PropTypes.string // The dataIndex of the column that is currently being sorted
 };

--- a/src/components/Table/Table.stories.js
+++ b/src/components/Table/Table.stories.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { css } from "styled-components";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select, object } from "@storybook/addon-knobs/react";
 

--- a/src/components/Table/Table.stories.js
+++ b/src/components/Table/Table.stories.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { css } from "styled-components";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select, object } from "@storybook/addon-knobs/react";
 

--- a/src/components/Table/components/TableRow.js
+++ b/src/components/Table/components/TableRow.js
@@ -23,6 +23,7 @@ const TableRowElement = styled.tr`
       & + tr {
         box-shadow: none;
       }
+      ${props.selectedRowStyle};
     `};
 `;
 
@@ -34,10 +35,15 @@ function TableRow({
   isSelected,
   onCellClick,
   rowIndex,
+  selectedRowStyle,
   accentColor = COLOR_BRAND_PRIMARY
 }) {
   return (
-    <TableRowElement isSelected={isSelected} accentColor={accentColor}>
+    <TableRowElement
+      isSelected={isSelected}
+      accentColor={accentColor}
+      selectedRowStyle={selectedRowStyle}
+    >
       {/* Because the `columns` array determines the desired column order, 
         we need to map through it and use the dataIndex property to pick out 
         the appropriate data for that column */}
@@ -65,7 +71,8 @@ TableRow.propTypes = {
   isRowSelected: PropTypes.bool,
   isSelected: PropTypes.bool,
   onCellClick: PropTypes.func,
-  rowIndex: PropTypes.number
+  rowIndex: PropTypes.number,
+  selectedRowStyle: PropTypes.object
 };
 
 export default TableRow;


### PR DESCRIPTION
When I was trying to modify this component for the workspaces table in data-ui, I realized that I couldn't edit the selected row styles. this pr adds a hook so that you can pass inline styles, or styled-component `css`` `