### PR TITLE
feat: less opinionated button styles

### DIFF
--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -37,7 +37,7 @@ exports[`Button Snapshots matches orientation snapshots 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -135,7 +135,7 @@ exports[`Button Snapshots matches orientation snapshots 2`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -235,7 +235,7 @@ exports[`Button Snapshots matches outline snapshots 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -348,7 +348,7 @@ exports[`Button Snapshots matches size snapshots 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -448,7 +448,7 @@ exports[`Button Snapshots matches size snapshots 2`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -549,7 +549,7 @@ exports[`Button Snapshots matches size snapshots 3`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -650,7 +650,7 @@ exports[`Button Snapshots matches size snapshots 4`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -750,7 +750,7 @@ exports[`Button Snapshots matches size snapshots 5`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -850,7 +850,7 @@ exports[`Button Snapshots matches type snapshots 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -951,7 +951,7 @@ exports[`Button Snapshots matches type snapshots 2`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -1052,7 +1052,7 @@ exports[`Button Snapshots matches type snapshots 3`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -1153,7 +1153,7 @@ exports[`Button Snapshots matches type snapshots 4`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/src/components/Button/components/ButtonWrap/ButtonWrap.js
+++ b/src/components/Button/components/ButtonWrap/ButtonWrap.js
@@ -5,7 +5,7 @@ import generateButtonOrientation from "./utils/generateButtonOrientation";
 import generateButtonSize from "./utils/generateButtonSize";
 import generateButtonStyle from "./utils/generateButtonStyle";
 
-import { FONT_WEIGHT_SEMIBOLD, FONT_STACK_BASE } from "style/styleVariables";
+import { FONT_STACK_BASE, FONT_WEIGHT_BASE } from "style/styleVariables";
 
 // The start of the CSS style output
 const ButtonWrap = styled.button`
@@ -16,7 +16,7 @@ const ButtonWrap = styled.button`
   cursor: pointer;
   display: flex;
   font-family: ${FONT_STACK_BASE};
-  font-weight: ${FONT_WEIGHT_SEMIBOLD};
+  font-weight: ${FONT_WEIGHT_BASE};
   justify-content: center;
   line-height: 1.4;
   text-align: center;

--- a/src/components/Button/components/ButtonWrap/__snapshots__/ButtonWrap.test.js.snap
+++ b/src/components/Button/components/ButtonWrap/__snapshots__/ButtonWrap.test.js.snap
@@ -15,7 +15,7 @@ exports[`ButtonWrap should match snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;


### PR DESCRIPTION
- Bringing the font weight of buttons back to the regular weight.
Higher weight makes buttons look odd in about 50% of uses, and in such a case I'd rather keep them unopinionated, rather than having to override a style later.