### PR TITLE
fix: update breadcrumb item to not just take strings

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbItem.js
+++ b/src/components/Breadcrumbs/BreadcrumbItem.js
@@ -46,12 +46,16 @@ export default function BreadcrumbItem({ item, expand }) {
         if (item === "...") expand();
       }}
     >
-      {item.length > 20 ? item.substr(0, 20).concat("...") : item}
+      {item}
     </Breadcrumb>
   );
 }
 
 BreadcrumbItem.propTypes = {
   expand: PropTypes.func,
-  item: PropTypes.string.isRequired
+  item: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+    PropTypes.element
+  ]).isRequired
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -46,28 +46,19 @@ class Breadcrumbs extends React.Component {
   expand = () => this.setState({ isCollapsed: false });
 
   renderCollapsed = crumbs => {
-    const elipsisItem = (
-      <BreadcrumbItem key={1} item={"..."} expand={this.expand} />
+    return (
+      <React.Fragment>
+        <BreadcrumbItem key={0} item={crumbs[0]} />
+        <BreadcrumbItem key={1} item={"..."} expand={this.expand} />
+        <BreadcrumbItem key={-1} item={crumbs[crumbs.length - 1]} />
+      </React.Fragment>
     );
-    const lastIndex = crumbs.length - 1;
-    const collapsedArr = [
-      <BreadcrumbItem key={0} item={crumbs[0]} />,
-      elipsisItem,
-      <BreadcrumbItem key={lastIndex} item={crumbs[lastIndex]} />
-    ];
-    return collapsedArr;
   };
 
   renderExpanded = crumbs => {
-    return crumbs.map((item, i) => {
-      return (
-        <BreadcrumbItem
-          key={i}
-          item={item}
-          hideDelimiter={crumbs.length === 1}
-        />
-      );
-    });
+    return crumbs.map((item, i) => (
+      <BreadcrumbItem key={i} item={item} hideDelimiter={crumbs.length === 1} />
+    ));
   };
 
   render() {
@@ -95,3 +86,5 @@ Breadcrumbs.propTypes = {
   crumbs: PropTypes.array.isRequired,
   maxItems: PropTypes.number
 };
+
+Breadcrumbs.displayName = "Breadcrumbs";

--- a/src/components/Breadcrumbs/Breadcrumbs.test.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.js
@@ -3,7 +3,6 @@ import renderer from "react-test-renderer";
 import { Breadcrumbs, BreadcrumbItem } from "./index.js";
 import { shallow } from "enzyme";
 
-
 const crumbs = [
   "Test 1",
   "Test 2",
@@ -50,17 +49,5 @@ describe("<Breadcrumbs>", () => {
       .dive()
       .simulate("click");
     expect(wrapper.state("isCollapsed")).toEqual(false);
-  });
-
-  test("a single breadcrumb is not longer than 20 characters", () => {
-    wrapper.find(BreadcrumbItem).forEach(item => {
-      expect(
-        item
-          .dive()
-          .dive()
-          .text().length
-      ).toBeLessThanOrEqual(23);
-      // 23 includes the elipsis...
-    });
   });
 });

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -82,7 +82,7 @@ exports[`<Breadcrumbs> Snapshot renders collapsed breadcrumbs correctly 1`] = `
     className="c1"
     onClick={[Function]}
   >
-    Testing a really lon...
+    Testing a really long breadcrumb item
   </li>
 </ol>
 `;
@@ -175,7 +175,7 @@ exports[`<Breadcrumbs> Snapshot renders expanded breadcrumbs correctly 1`] = `
     className="c1"
     onClick={[Function]}
   >
-    Testing a really lon...
+    Testing a really long breadcrumb item
   </li>
 </ol>
 `;


### PR DESCRIPTION
This doesn't close out issue #270 as we should probably consider refactoring further, but I wanted to resolve the string issue to avoid proptype errors.