### PR TITLE
feat: better default size for icons

### DIFF
--- a/src/components/Icon/components/StyledSVG.js
+++ b/src/components/Icon/components/StyledSVG.js
@@ -10,8 +10,8 @@ const StyledSVG = styled.svg.attrs({
   preserveAspectRatio: "xMaxYMax meet"
 })`
   z-index: 1;
-  width: ${props => (props.size ? props.size : "100%")};
-  height: ${props => (props.size ? props.size : "auto")};
+  width: ${props => (props.size ? props.size : "1.714em")};
+  height: ${props => (props.size ? props.size : "1.714em")};
   word-spacing: 0;
   vertical-align: middle;
   &:not(:root) {

--- a/src/components/Icon/components/__snapshots__/StyledSVG.test.js.snap
+++ b/src/components/Icon/components/__snapshots__/StyledSVG.test.js.snap
@@ -3,8 +3,8 @@
 exports[`StyledSVG matches snapshot 1`] = `
 .c0 {
   z-index: 1;
-  width: 100%;
-  height: auto;
+  width: 1.714em;
+  height: 1.714em;
   word-spacing: 0;
   vertical-align: middle;
 }


### PR DESCRIPTION
- Default size for icons now `1.714em` instead of as large as possible, `100%`.