### PR TITLE
fix: camel case Input component autoFocus prop

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -7,7 +7,7 @@ import InputHint from "./components/InputHint";
 import InputField from "./components/InputField";
 
 Input.propTypes = {
-  autofocus: PropTypes.bool,
+  autoFocus: PropTypes.bool,
   defaultValue: PropTypes.string,
   hint: PropTypes.string,
   label: PropTypes.string,
@@ -17,7 +17,7 @@ Input.propTypes = {
 };
 
 export default function Input({
-  autofocus,
+  autoFocus,
   defaultValue,
   hint,
   label,
@@ -31,7 +31,7 @@ export default function Input({
       {label && <InputLabel>{label}</InputLabel>}
       <InputField
         type={type}
-        autofocus={autofocus}
+        autoFocus={autoFocus}
         defaultValue={defaultValue}
         placeholder={placeholder}
         maxLength={maxLength}

--- a/src/components/Input/Input.stories.js
+++ b/src/components/Input/Input.stories.js
@@ -6,11 +6,11 @@ import Input from "./Input";
 
 storiesOf("Input", module).add("default", () => (
   <Input
-    autofocus={boolean("Autofocus", false)}
-    hint={text("Hint", "Hint")}
-    label={text("Label", "Label")}
+    autoFocus={boolean("autoFocus", false)}
+    hint={text("hint", "hint")}
+    label={text("label", "label")}
     defaultValue={text("defaultValue", "defaultValue")}
-    placeholder={text("Placeholder", "Placeholder")}
+    placeholder={text("placeholder", "placeholder")}
     maxLength={number("maxLength", 25)}
   />
 ));

--- a/src/components/Input/components/InputField.js
+++ b/src/components/Input/components/InputField.js
@@ -4,7 +4,7 @@ import { FONT_SIZE_BASE, FONT_STACK_BASE, COLOR_KEYLINE, COLOR_CONTENT, COLOR_BA
 import { spacingScale } from 'style/styleFunctions';
 
 export const InputField = styled.input.attrs({
-  autoFocus: props => props.autofocus,
+  autoFocus: props => props.autoFocus,
   defaultValue: props => props.defaultValue,
   placeholder: props => props.placeholder,
   maxLength: props => props.maxlength,


### PR DESCRIPTION
This PR adds camelCasing to the Input components's `autoFocus` prop.  It was breaking tests in the dashboard.

```
 FAIL  src/components/Main/components/MainContent/scenes/ServiceView/scenes/ServiceConfigurationView/components/ObjectivesForm/ObjectivesForm.test.js
  ● Objectives Form › matches snapshot

    Error: Uncaught [Error: Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?
        in input (created by InputField)
```