### PR TITLE
refactor: use react-popper positioning engine with tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4618,6 +4618,22 @@
       "integrity": "sha512-DOzWZKUnmFYG0KUOs+9HEBju2QhBU6oM2zeluunQNt0vnJvnkHvtDNlQPZDkTrkC5pZrNx1TPqeL137zciXZMQ==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
+      "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.7.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.13.tgz",
+      "integrity": "sha512-WhqrQLAE9z65hfcvWqZfR6qUtIazFRyb8LXqHo8440R53dAQqNkt2OlVJ3FXwqOwAXXg4nfYxt0qgBvE18o5XA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
     "JSONStream": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
@@ -8693,6 +8709,16 @@
         "object-assign": "^4.1.1"
       }
     },
+    "create-react-context": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -11849,6 +11875,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
       "dev": true
     },
     "gzip-size": {
@@ -16624,6 +16656,12 @@
       "resolved": "https://registry.npmjs.org/polished/-/polished-2.0.3.tgz",
       "integrity": "sha512-MMwthxXsmZZlZY/x79KX/8kXpSU0lq3ntnDmAdhpQGk9pU9EM/rQmUbsgIuuk2Cvl6zYSWjyBsDEU8sa1598xg=="
     },
+    "popper.js": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
+      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -18453,6 +18491,21 @@
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
       "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==",
       "dev": true
+    },
+    "react-popper": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.0.tgz",
+      "integrity": "sha512-Dbn9kwgFzNFRi8yz/i4Qp7d1hkCYhWX6uJOFz0+PoNNm9uJMnFAqSPNgUUCV49L6p5zz5mKtMiudbgIqjAe1uw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "^16.1.0",
+        "babel-runtime": "6.x.x",
+        "create-react-context": "^0.2.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.5",
+        "warning": "^3.0.0"
+      }
     },
     "react-split-pane": {
       "version": "0.1.84",
@@ -20991,8 +21044,8 @@
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.1",
-            "ieee754": "1.1.8"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         },
         "has-flag": {
@@ -21538,6 +21591,12 @@
           }
         }
       }
+    },
+    "typed-styles": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.5.tgz",
+      "integrity": "sha512-ht+rEe5UsdEBAa3gr64+QjUOqjOLJfWLvl5HZR5Ev9uo/OnD3p43wPeFSB1hNFc13GXQF/JU1Bn0YHLUqBRIlw==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react": "^16.4.2",
     "react-docgen": "^2.21.0",
     "react-dom": "^16.4.2",
+    "react-popper": "^1.3.0",
     "react-test-renderer": "^16.4.2",
     "storybook-addon-styled-component-theme": "^1.0.7",
     "styled-components": "^3.4.8",

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -1,26 +1,57 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { Manager, Reference, Popper } from "react-popper";
 import TooltipContent from "./components/TooltipContent";
 import TooltipWrap from "./components/TooltipWrap";
 
-export default function Tooltip({
-  children,
-  content,
-  position,
-  hideTooltip,
-  tooltipStyle = {},
-  ...props
-}) {
-  // Always hide the tooltip if the content is empty
-  if (!content) hideTooltip = true;
-  return (
-    <TooltipWrap hideTooltip={hideTooltip} {...props}>
-      {children}
-      <TooltipContent style={tooltipStyle} position={position}>
-        {content}
-      </TooltipContent>
-    </TooltipWrap>
-  );
+export default class Tooltip extends React.Component {
+  state = {
+    visible: false
+  };
+
+  toggleVisibility = () => this.setState({ visible: !this.state.visible });
+
+  render() {
+    let {
+      children,
+      content,
+      position,
+      hideTooltip,
+      tooltipStyle = {},
+      ...props
+    } = this.props;
+    // Always hide the tooltip if the content is empty
+    if (!content) hideTooltip = true;
+    return (
+      <Manager>
+        <Reference>
+          {({ ref }) => (
+            <TooltipWrap
+              innerRef={ref}
+              onMouseEnter={this.toggleVisibility}
+              onMouseLeave={this.toggleVisibility}
+              {...props}
+            >
+              {children}
+            </TooltipWrap>
+          )}
+        </Reference>
+        <Popper placement={position}>
+          {({ ref, style, placement }) => {
+            return (
+              <TooltipContent
+                innerRef={ref}
+                style={{ ...style, ...tooltipStyle }}
+                visible={!hideTooltip && this.state.visible}
+              >
+                {content}
+              </TooltipContent>
+            );
+          }}
+        </Popper>
+      </Manager>
+    );
+  }
 }
 
 Tooltip.propTypes = {

--- a/src/components/Tooltip/Tooltip.stories.js
+++ b/src/components/Tooltip/Tooltip.stories.js
@@ -17,14 +17,16 @@ stories.add(
       "right"
     );
     return (
-      <Tooltip
-        content={content}
-        position={position}
-        hideTooltip={boolean("hideTooltip", false)}
-        tooltipStyle={object("tooltipStyle", {})}
-      >
-        {text("children", "Hover over me")}
-      </Tooltip>
+      <div style={{ textAlign: "center" }}>
+        <Tooltip
+          content={content}
+          position={position}
+          hideTooltip={boolean("hideTooltip", false)}
+          tooltipStyle={object("tooltipStyle", {})}
+        >
+          {text("children", "Hover over me")}
+        </Tooltip>
+      </div>
     );
   })
 );

--- a/src/components/Tooltip/Tooltip.test.js
+++ b/src/components/Tooltip/Tooltip.test.js
@@ -1,17 +1,14 @@
 import React from "react";
-import renderer from "react-test-renderer";
-import { render } from "enzyme";
+import { shallow } from "enzyme";
 
 import Tooltip from "./Tooltip";
 
 function renderTooltip(position) {
-  return renderer
-    .create(
-      <Tooltip content="Hello!" position={position}>
-        Hover over me
-      </Tooltip>
-    )
-    .toJSON();
+  return shallow(
+    <Tooltip content="Hello!" position={position}>
+      Hover over me
+    </Tooltip>
+  );
 }
 
 describe("Tooltip", () => {
@@ -28,7 +25,7 @@ describe("Tooltip", () => {
   });
 
   it("renders a tooltip div with the correct content", () => {
-    const wrapper = render(
+    const wrapper = shallow(
       <Tooltip content="Hello!" position={"top"}>
         Hover over me
       </Tooltip>

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -1,201 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip correctly positions tooltip content based on position prop 1`] = `
-Array [
-  .c0 {
-  display: inline-block;
-  position: relative;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-}
-
-<div
-    className="c0"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+<Manager>
+  <Reference>
+    <Component />
+  </Reference>
+  <Popper
+    placement="top"
   >
-    Hover over me
-  </div>,
-  .c0 {
-  background-color: #fff;
-  border-radius: 3px;
-  color: #000;
-  box-shadow: 0 0 0 1px #EBEBEB;
-  font-size: 14px;
-  padding: 8px;
-  width: 160px;
-  z-index: 1070;
-  text-align: left;
-  -webkit-transition: opacity 1s;
-  transition: opacity 1s;
-  opacity: 0;
-  white-space: normal;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  margin: 8px;
-}
-
-<div
-    className="c0"
-    style={
-      Object {
-        "left": 0,
-        "opacity": 0,
-        "pointerEvents": "none",
-        "position": "absolute",
-        "top": 0,
-      }
-    }
-  >
-    Hello!
-  </div>,
-]
+    <Component />
+  </Popper>
+</Manager>
 `;
 
 exports[`Tooltip correctly positions tooltip content based on position prop 2`] = `
-Array [
-  .c0 {
-  display: inline-block;
-  position: relative;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-}
-
-<div
-    className="c0"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+<Manager>
+  <Reference>
+    <Component />
+  </Reference>
+  <Popper
+    placement="bottom"
   >
-    Hover over me
-  </div>,
-  .c0 {
-  background-color: #fff;
-  border-radius: 3px;
-  color: #000;
-  box-shadow: 0 0 0 1px #EBEBEB;
-  font-size: 14px;
-  padding: 8px;
-  width: 160px;
-  z-index: 1070;
-  text-align: left;
-  -webkit-transition: opacity 1s;
-  transition: opacity 1s;
-  opacity: 0;
-  white-space: normal;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  margin: 8px;
-}
-
-<div
-    className="c0"
-    style={
-      Object {
-        "left": 0,
-        "opacity": 0,
-        "pointerEvents": "none",
-        "position": "absolute",
-        "top": 0,
-      }
-    }
-  >
-    Hello!
-  </div>,
-]
+    <Component />
+  </Popper>
+</Manager>
 `;
 
 exports[`Tooltip correctly positions tooltip content based on position prop 3`] = `
-Array [
-  .c0 {
-  display: inline-block;
-  position: relative;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-}
-
-<div
-    className="c0"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+<Manager>
+  <Reference>
+    <Component />
+  </Reference>
+  <Popper
+    placement="left"
   >
-    Hover over me
-  </div>,
-  .c0 {
-  background-color: #fff;
-  border-radius: 3px;
-  color: #000;
-  box-shadow: 0 0 0 1px #EBEBEB;
-  font-size: 14px;
-  padding: 8px;
-  width: 160px;
-  z-index: 1070;
-  text-align: left;
-  -webkit-transition: opacity 1s;
-  transition: opacity 1s;
-  opacity: 0;
-  white-space: normal;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  margin: 8px;
-}
-
-<div
-    className="c0"
-    style={
-      Object {
-        "left": 0,
-        "opacity": 0,
-        "pointerEvents": "none",
-        "position": "absolute",
-        "top": 0,
-      }
-    }
-  >
-    Hello!
-  </div>,
-]
+    <Component />
+  </Popper>
+</Manager>
 `;
 
 exports[`Tooltip correctly positions tooltip content based on position prop 4`] = `
-Array [
-  .c0 {
-  display: inline-block;
-  position: relative;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-}
-
-<div
-    className="c0"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+<Manager>
+  <Reference>
+    <Component />
+  </Reference>
+  <Popper
+    placement="right"
   >
-    Hover over me
-  </div>,
-  .c0 {
-  background-color: #fff;
-  border-radius: 3px;
-  color: #000;
-  box-shadow: 0 0 0 1px #EBEBEB;
-  font-size: 14px;
-  padding: 8px;
-  width: 160px;
-  z-index: 1070;
-  text-align: left;
-  -webkit-transition: opacity 1s;
-  transition: opacity 1s;
-  opacity: 0;
-  white-space: normal;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-  margin: 8px;
-}
-
-<div
-    className="c0"
-    style={
-      Object {
-        "left": 0,
-        "opacity": 0,
-        "pointerEvents": "none",
-        "position": "absolute",
-        "top": 0,
-      }
-    }
-  >
-    Hello!
-  </div>,
-]
+    <Component />
+  </Popper>
+</Manager>
 `;

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -1,7 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip correctly positions tooltip content based on position prop 1`] = `
-.c1 {
+Array [
+  .c0 {
+  display: inline-block;
+  position: relative;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
+}
+
+<div
+    className="c0"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    Hover over me
+  </div>,
+  .c0 {
   background-color: #fff;
   border-radius: 3px;
   color: #000;
@@ -10,45 +24,48 @@ exports[`Tooltip correctly positions tooltip content based on position prop 1`] 
   padding: 8px;
   width: 160px;
   z-index: 1070;
-  opacity: 0;
-  position: absolute;
   text-align: left;
   -webkit-transition: opacity 1s;
   transition: opacity 1s;
-  visibility: hidden;
+  opacity: 0;
   white-space: normal;
-  bottom: 150%;
-  left: 50%;
-  margin-left: -80px;
-}
-
-.c0 {
-  display: inline-block;
-  position: relative;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-}
-
-.c0:hover >:last-child {
-  opacity: 1;
-  visibility: visible;
-  z-index: 1070;
+  margin: 8px;
 }
 
 <div
-  className="c0"
->
-  Hover over me
-  <div
-    className="c1"
-    style={Object {}}
+    className="c0"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
   >
     Hello!
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`Tooltip correctly positions tooltip content based on position prop 2`] = `
-.c1 {
+Array [
+  .c0 {
+  display: inline-block;
+  position: relative;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
+}
+
+<div
+    className="c0"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    Hover over me
+  </div>,
+  .c0 {
   background-color: #fff;
   border-radius: 3px;
   color: #000;
@@ -57,45 +74,48 @@ exports[`Tooltip correctly positions tooltip content based on position prop 2`] 
   padding: 8px;
   width: 160px;
   z-index: 1070;
-  opacity: 0;
-  position: absolute;
   text-align: left;
   -webkit-transition: opacity 1s;
   transition: opacity 1s;
-  visibility: hidden;
+  opacity: 0;
   white-space: normal;
-  top: 150%;
-  left: 50%;
-  margin-left: -80px;
-}
-
-.c0 {
-  display: inline-block;
-  position: relative;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-}
-
-.c0:hover >:last-child {
-  opacity: 1;
-  visibility: visible;
-  z-index: 1070;
+  margin: 8px;
 }
 
 <div
-  className="c0"
->
-  Hover over me
-  <div
-    className="c1"
-    style={Object {}}
+    className="c0"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
   >
     Hello!
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`Tooltip correctly positions tooltip content based on position prop 3`] = `
-.c1 {
+Array [
+  .c0 {
+  display: inline-block;
+  position: relative;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
+}
+
+<div
+    className="c0"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    Hover over me
+  </div>,
+  .c0 {
   background-color: #fff;
   border-radius: 3px;
   color: #000;
@@ -104,44 +124,48 @@ exports[`Tooltip correctly positions tooltip content based on position prop 3`] 
   padding: 8px;
   width: 160px;
   z-index: 1070;
-  opacity: 0;
-  position: absolute;
   text-align: left;
   -webkit-transition: opacity 1s;
   transition: opacity 1s;
-  visibility: hidden;
+  opacity: 0;
   white-space: normal;
-  right: 120%;
-  top: -5px;
-}
-
-.c0 {
-  display: inline-block;
-  position: relative;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-}
-
-.c0:hover >:last-child {
-  opacity: 1;
-  visibility: visible;
-  z-index: 1070;
+  margin: 8px;
 }
 
 <div
-  className="c0"
->
-  Hover over me
-  <div
-    className="c1"
-    style={Object {}}
+    className="c0"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
   >
     Hello!
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`Tooltip correctly positions tooltip content based on position prop 4`] = `
-.c1 {
+Array [
+  .c0 {
+  display: inline-block;
+  position: relative;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
+}
+
+<div
+    className="c0"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    Hover over me
+  </div>,
+  .c0 {
   background-color: #fff;
   border-radius: 3px;
   color: #000;
@@ -150,38 +174,28 @@ exports[`Tooltip correctly positions tooltip content based on position prop 4`] 
   padding: 8px;
   width: 160px;
   z-index: 1070;
-  opacity: 0;
-  position: absolute;
   text-align: left;
   -webkit-transition: opacity 1s;
   transition: opacity 1s;
-  visibility: hidden;
+  opacity: 0;
   white-space: normal;
-  top: -5px;
-  left: 120%;
-}
-
-.c0 {
-  display: inline-block;
-  position: relative;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
-}
-
-.c0:hover >:last-child {
-  opacity: 1;
-  visibility: visible;
-  z-index: 1070;
+  margin: 8px;
 }
 
 <div
-  className="c0"
->
-  Hover over me
-  <div
-    className="c1"
-    style={Object {}}
+    className="c0"
+    style={
+      Object {
+        "left": 0,
+        "opacity": 0,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": 0,
+      }
+    }
   >
     Hello!
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/src/components/Tooltip/components/TooltipContent.js
+++ b/src/components/Tooltip/components/TooltipContent.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { spacingScale } from "style/styleFunctions";
 import {
+  FONT_STACK_BASE,
   FONT_SIZE_BASE,
   ZINDEX_TOOLTIP,
   BORDER_RADIUS_BASE,
@@ -20,38 +21,12 @@ const TooltipContent = styled.div`
   padding: ${spacingScale(1)};
   width: ${spacingScale(20)};
   z-index: ${ZINDEX_TOOLTIP};
-  opacity: 0;
-  position: absolute;
   text-align: left;
   transition: opacity 1s;
-  visibility: hidden;
+  opacity: ${props => (props.visible ? 1 : 0)};
   white-space: normal;
-  /* Position the tooltip */
-  ${props => getPosition(props.position)};
+  font-family: ${FONT_STACK_BASE};
+  margin: ${spacingScale(1)};
 `;
-
-function getPosition(position) {
-  switch (position) {
-    case "top":
-      return `
-      bottom: 150%;
-      left: 50%; 
-      margin-left: -80px;`;
-    case "left":
-      return `
-      right: 120%;
-      top: -5px;`;
-    case "right":
-      return `
-      top: -5px;
-      left: 120%;`;
-    case "bottom":
-    default:
-      return `
-      top: 150%;
-      left: 50%; 
-      margin-left: -80px`;
-  }
-}
 
 export default TooltipContent;

--- a/src/components/Tooltip/components/TooltipWrap.js
+++ b/src/components/Tooltip/components/TooltipWrap.js
@@ -1,19 +1,10 @@
-import styled, { css } from "styled-components";
-import { ZINDEX_TOOLTIP, FONT_STACK_BASE } from "style/styleVariables";
+import styled from "styled-components";
+import { FONT_STACK_BASE } from "style/styleVariables";
 
 const TooltipWrap = styled.div`
   display: inline-block;
   position: relative;
   font-family: ${FONT_STACK_BASE};
-  :hover > :last-child {
-    ${props =>
-      !props.hideTooltip &&
-      css`
-        opacity: 1;
-        visibility: visible;
-        z-index: ${ZINDEX_TOOLTIP};
-      `};
-  }
 `;
 
 export default TooltipWrap;


### PR DESCRIPTION
To test

- `npm install`, view Tooltip in storybook and play with props
- `npm link && npm run build -- --watch`
- In the dashboard, run `npm link gm-ui-components && npm run start:proxy` linking will NOT work in the dc environment