### PR TITLE
fix: readout styles, add missing theme exports

### DIFF
--- a/src/components/Readout/Readout.js
+++ b/src/components/Readout/Readout.js
@@ -12,7 +12,7 @@ export default function Readout({
   ...props
 }) {
   return (
-    <ReadoutDisplay primary={primary} {...props}>
+    <ReadoutDisplay color={color} primary={primary} {...props}>
       {readoutItems.map(item => (
         <ReadoutItem
           key={`${item.title}|${item.value}|${item.detail}`}

--- a/src/components/Readout/Readout.stories.js
+++ b/src/components/Readout/Readout.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import { IconSummary } from "../";
 
 import { storiesOf } from "@storybook/react";
-import { boolean, object } from "@storybook/addon-knobs";
+import { boolean, object, color } from "@storybook/addon-knobs";
 
 import ReadoutGroup from "../ReadoutGroup/ReadoutGroup";
 import Readout from "./Readout";
@@ -50,6 +50,7 @@ stories
     () => {
       return (
         <Readout
+          color={color("color")}
           primary={boolean("primary", false)}
           readoutItems={object("readoutItems", mockReadoutItem)}
         />
@@ -66,6 +67,7 @@ stories
     () => {
       return (
         <Readout
+          color={color("color")}
           primary={boolean("primary", false)}
           readoutItems={object("readoutItems", mockReadoutManyItems)}
         />

--- a/src/components/Readout/__snapshots__/Readout.test.js.snap
+++ b/src/components/Readout/__snapshots__/Readout.test.js.snap
@@ -120,6 +120,7 @@ exports[`Readout matches snapshot when primary is true or false 2`] = `
 
 exports[`Readout matches snapshot when rendering readoutItems 1`] = `
 <ReadoutDisplay
+  color="#0a2"
   theme={
     Object {
       "BORDER_RADIUS_BASE": "3px",
@@ -190,6 +191,7 @@ exports[`Readout matches snapshot when rendering readoutItems 1`] = `
 
 exports[`Readout matches snapshot when taking a color prop 1`] = `
 <ReadoutDisplay
+  color="#0a2"
   theme={
     Object {
       "BORDER_RADIUS_BASE": "3px",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,3 +22,4 @@ export { default as InputRange } from "./Form/scenes/InputRange";
 export { default as Textarea } from "./Form/scenes/Textarea";
 export { default as Radio } from "./Form/scenes/Radio";
 export { default as Select } from "./Form/scenes/Select";
+export { keen, keenDark } from "../style/styleVariables";


### PR DESCRIPTION
- pass color prop to ReadoutDisplay
- export keen and keenDark from the lib so people can use them and extend the defaults

to test
- `npm start` and check readout styles, change the color knob