### PR TITLE
fix: fix theme background color applying to entire storycontainer

### DIFF
--- a/src/ComponentLibrary/StoryComponents/StoryContainer.js
+++ b/src/ComponentLibrary/StoryComponents/StoryContainer.js
@@ -5,8 +5,6 @@ import { keen } from "style/styleVariables";
 import GlobalStyles from "style/GlobalStyles";
 
 const Wrap = styled.div`
-  background-color: ${props => props.theme.COLOR_BACKGROUND_A};
-  color: ${props => props.theme.COLOR_CONTENT};
   width: 100%;
   display: flex;
   flex: 1 1 100%;


### PR DESCRIPTION
- Fix dark theme background appearing to stretch beyond the component box area.

Before:
<img width="1175" alt="Screen Shot 2019-05-29 at 12 54 19 PM" src="https://user-images.githubusercontent.com/98312/58575830-f13e7280-8210-11e9-97cc-59945d7a68ee.png">

After:
<img width="1175" alt="Screen Shot 2019-05-29 at 12 54 31 PM" src="https://user-images.githubusercontent.com/98312/58575835-f6032680-8210-11e9-91b3-3ea217c4d85a.png">
