### PR TITLE
fix: lower global link style specificity

### DIFF
--- a/src/style/GlobalStyles.js
+++ b/src/style/GlobalStyles.js
@@ -431,7 +431,7 @@ const GlobalStyles = createGlobalStyle`
     color: ${props => props.theme.COLOR_CONTENT};
   }
 
-  a:link {
+  a {
     color: ${props => props.theme.COLOR_INTENT_HIGHLIGHT};
   }
 


### PR DESCRIPTION
`a:link` had unintended consequences over `a`, including breaking AppFooter link colors.

It’s preferable to make fewer assumptions at the global level than to force more overrides down the tree.