### PR TITLE
feat: show all props gallery for button component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -3,6 +3,7 @@ import { configure, addDecorator, addParameters } from "@storybook/react";
 import { withInfo } from "@storybook/addon-info";
 import { withOptions } from "@storybook/addon-options";
 import { withKnobs } from "@storybook/addon-knobs";
+import { setDefaults } from "react-storybook-addon-props-combinations";
 import { withThemesProvider } from "storybook-addon-styled-component-theme";
 import gmTheme from "./gmTheme";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15360,6 +15360,12 @@
         }
       }
     },
+    "object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -17197,6 +17203,34 @@
         "raf": "^3.4.0",
         "react-input-autosize": "^2.2.1",
         "react-transition-group": "^2.2.1"
+      }
+    },
+    "react-storybook-addon-props-combinations": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-storybook-addon-props-combinations/-/react-storybook-addon-props-combinations-1.1.0.tgz",
+      "integrity": "sha512-gCHyLTkXthuP3wV5nQn3A6ZrBjYnRniRtVprSrq+7Vu9SX1jUhIEPvqdLdPVRmlq9rwgKAX2QVo6kNd95kZ7Hw==",
+      "dev": true,
+      "requires": {
+        "object-hash": "^1.1.8",
+        "pretty-format": "^21.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "21.2.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+          "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        }
       }
     },
     "react-syntax-highlighter": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
     "react-popper": "^1.3.3",
+    "react-storybook-addon-props-combinations": "^1.1.0",
     "react-test-renderer": "^16.8.2",
     "regenerator-runtime": "^0.13.1",
     "storybook-addon-styled-component-theme": "^1.2.1",

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -2,6 +2,7 @@ import React from "react";
 
 import { storiesOf } from "@storybook/react";
 import { number, select, text, color, boolean } from "@storybook/addon-knobs";
+import withPropsCombinations from "react-storybook-addon-props-combinations";
 
 import { IconBell } from "components/Glyphs";
 import Button from "./Button";
@@ -9,7 +10,7 @@ import Button from "./Button";
 const stories = storiesOf("Components|Buttons", module);
 
 const types = ["default", "danger", "info", "primary", "warning"];
-const sizes = ["normal", "xs", "sm", "lg", "xl"];
+const sizes = ["xs", "sm", "normal", "lg", "xl"];
 const orientations = ["vertical", "horizontal"];
 
 stories
@@ -35,6 +36,33 @@ stories
       info: {
         text:
           "A React component that renders a button and includes base styling, used to trigger actions."
+      }
+    }
+  )
+  .add(
+    "Props Gallery",
+    withPropsCombinations(
+      Button,
+      {
+        type: types,
+        active: [false, true],
+        outline: [false, true],
+        disabled: [false, true],
+        size: sizes,
+        label: ["Label"]
+      },
+      {
+        showSource: false,
+        style: {
+          float: "left",
+          margin: "0.25rem"
+        }
+      }
+    ),
+    {
+      info: {
+        text:
+          "All Button types, active states, disabled states, sizes, and outline states."
       }
     }
   )

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -6,6 +6,8 @@ import withPropsCombinations from "react-storybook-addon-props-combinations";
 
 import { IconBell } from "components/Glyphs";
 import Button from "./Button";
+import copy from "copy-to-clipboard";
+import Tooltip from "components/Tooltip";
 
 const stories = storiesOf("Components|Buttons", module);
 
@@ -56,6 +58,21 @@ stories
         style: {
           float: "left",
           margin: "0.25rem"
+        },
+        CombinationRenderer: ({ Component, props, options }) => {
+          const prettyJSON = JSON.stringify(props)
+            .split(",")
+            .join("\n");
+          return (
+            <Tooltip content={prettyJSON}>
+              <Component
+                {...props}
+                title="Click to copy props"
+                style={options.style}
+                onClick={() => copy(JSON.stringify(props))}
+              />
+            </Tooltip>
+          );
         }
       }
     ),

--- a/src/components/Tooltip/components/TooltipContent.js
+++ b/src/components/Tooltip/components/TooltipContent.js
@@ -18,6 +18,7 @@ const TooltipContent = styled.div`
   white-space: normal;
   font-family: ${props => props.theme.FONT_STACK_BASE};
   margin: ${spacingScale(1)};
+  word-wrap: break-word;
 
   ${props =>
     props.visible


### PR DESCRIPTION
Closes #469

- Add `withPropsCombinations` function to Button stories to demonstrate component props.

After:
<img width="992" alt="image" src="https://user-images.githubusercontent.com/98312/58732926-f3473380-83c0-11e9-9707-d7b75e7c265f.png">