### PR TITLE
fix: make button size generator use proper font sizes

### DIFF
--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -754,7 +754,7 @@ exports[`Button Snapshots matches size snapshots 4`] = `
   background-color: #ffffff;
   border-color: transparent;
   color: #000;
-  font-size: 18px;
+  font-size: 16px;
   border-radius: 4px;
   padding: 2px 10px;
   -webkit-flex-direction: row;

--- a/src/components/Button/components/ButtonWrap/utils/generateButtonSize.js
+++ b/src/components/Button/components/ButtonWrap/utils/generateButtonSize.js
@@ -4,6 +4,7 @@ import {
   FONT_SIZE_XS,
   FONT_SIZE_SM,
   FONT_SIZE_LG,
+  FONT_SIZE_MD,
   RADIUS_05
 } from "style/styleVariables";
 
@@ -63,7 +64,7 @@ function generateButtonSize(size) {
     }
     case "lg": {
       style = _buttonSizeStyleBlockGenerator({
-        fontSize: FONT_SIZE_LG,
+        fontSize: FONT_SIZE_MD,
         horizontalPadding: spacingScale(1.25),
         verticalPadding: spacingScale(0.25),
         textIsUppercase: false

--- a/src/components/Button/components/ButtonWrap/utils/generateButtonSize.test.js
+++ b/src/components/Button/components/ButtonWrap/utils/generateButtonSize.test.js
@@ -15,7 +15,7 @@ describe("generateButtonSize", () => {
     text-transform: uppercase;
   `);
     expect(generateButtonSize("lg")).toContain(`
-    font-size: 18px;
+    font-size: 16px;
     border-radius: 4px;
     padding: 2px 10px;
   `);


### PR DESCRIPTION
Closes #474 

Before: 
```xs: 9px
sm: 11px
normal: 14px
lg: 18px
xl: 18px
```

After: 
```xs: 9px
sm: 11px
normal: 14px
lg: 16px
xl: 18px
```
