### PR TITLE
feat: Input display text

### DIFF
--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -1,35 +1,59 @@
 import React from "react";
 import { PropTypes } from "prop-types";
+import styled from "styled-components";
 
-import InputLabelText from "components/util/InputLabelText";
 import InputWrap from "components/util/InputWrap";
-
+import InputLabelText from "components/util/InputLabelText";
+import InputLabelValue from "components/util/InputLabelValue";
+import { IconCheckmark, IconX } from "components/Glyphs";
 import CheckboxBox from "./components/CheckboxBox";
+import { spacingScale } from "style/styleFunctions";
+
+const AlginedIcon = styled.div`
+  margin: 0 0 ${spacingScale(-0.25)} ${spacingScale(-0.5)};
+`;
 
 const Checkbox = ({
+  checked,
+  defaultChecked,
+  disabled,
+  displayAsText,
   label,
   labelPosition,
-  value,
-  defaultChecked,
   readonly,
-  disabled,
+  value,
   ...props
 }) => {
   return (
     <InputWrap labelPosition={labelPosition} {...props}>
-      {label && <InputLabelText>{label}</InputLabelText>}
-      <CheckboxBox
-        defaultChecked={defaultChecked}
-        value={value}
-        disabled={disabled}
-      />
+      {displayAsText && (
+        <>
+          {label && <InputLabelValue>{label}</InputLabelValue>}
+          <AlginedIcon>
+            {checked && <IconCheckmark />}
+            {!checked && <IconX />}
+          </AlginedIcon>
+        </>
+      )}
+      {!displayAsText && (
+        <>
+          {label && <InputLabelText>{label}</InputLabelText>}
+          <CheckboxBox
+            defaultChecked={defaultChecked}
+            value={value}
+            disabled={disabled}
+          />
+        </>
+      )}
     </InputWrap>
   );
 };
 
 Checkbox.propTypes = {
+  checked: PropTypes.bool,
   defaultChecked: PropTypes.bool,
   disabled: PropTypes.bool,
+  displayAsText: PropTypes.bool,
   label: PropTypes.string.isRequired,
   labelPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
   onChange: PropTypes.func,
@@ -38,8 +62,10 @@ Checkbox.propTypes = {
 };
 
 Checkbox.defaultProps = {
+  checked: false,
   defaultChecked: false,
   disabled: false,
+  displayAsText: false,
   labelPosition: "right",
   readonly: false
 };

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -20,12 +20,13 @@ export default function InputField({
   placeholder,
   type,
   style,
+  value,
   ...props
 }) {
   return (
     <InputWrap labelPosition={labelPosition} style={style}>
       {label && <InputLabelText>{label}</InputLabelText>}
-      {displayAsText && <InputLabelValue>{props.value}</InputLabelValue>}
+      {displayAsText && <InputLabelValue>{value}</InputLabelValue>}
       {!displayAsText && (
         <>
           <InputTextField
@@ -64,7 +65,8 @@ InputField.propTypes = {
     "text",
     "url",
     "number"
-  ]).isRequired
+  ]).isRequired,
+  value: PropTypes.oneOf(["string", "number"])
 };
 
 InputField.defaultProps = {

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -1,8 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import InputLabelText from "components/util/InputLabelText";
 import InputWrap from "components/util/InputWrap";
+import InputLabelText from "components/util/InputLabelText";
+import InputLabelValue from "components/util/InputLabelValue";
 import InputHint from "components/util/InputHint";
 import InputTextField from "components/util/InputTextField";
 
@@ -11,6 +12,7 @@ export default function InputField({
   defaultValue,
   readonly,
   disabled,
+  displayAsText,
   hint,
   label,
   labelPosition,
@@ -23,17 +25,21 @@ export default function InputField({
   return (
     <InputWrap labelPosition={labelPosition} style={style}>
       {label && <InputLabelText>{label}</InputLabelText>}
-      <InputTextField
-        type={type}
-        autoFocus={autoFocus}
-        defaultValue={defaultValue}
-        disabled={disabled}
-        readonly
-        maxLength={maxLength}
-        placeholder={placeholder}
-        {...props}
-      />
-      {hint && <InputHint>{hint}</InputHint>}
+      {displayAsText && <InputLabelValue>{props.value}</InputLabelValue>}
+      {!displayAsText && (
+        <>
+          <InputTextField
+            type={type}
+            autoFocus={autoFocus}
+            defaultValue={defaultValue}
+            disabled={disabled}
+            maxLength={maxLength}
+            placeholder={placeholder}
+            {...props}
+          />
+          {hint && <InputHint>{hint}</InputHint>}
+        </>
+      )}
     </InputWrap>
   );
 }
@@ -42,6 +48,7 @@ InputField.propTypes = {
   autoFocus: PropTypes.bool,
   defaultValue: PropTypes.string,
   disabled: PropTypes.bool,
+  displayAsText: PropTypes.bool,
   hint: PropTypes.string,
   label: PropTypes.string,
   labelPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
@@ -63,6 +70,7 @@ InputField.propTypes = {
 InputField.defaultProps = {
   autoFocus: false,
   disabled: false,
+  displayAsText: false,
   labelPosition: "top",
   readonly: false,
   type: "text"

--- a/src/components/InputField/__snapshots__/InputField.test.js.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.js.snap
@@ -146,7 +146,6 @@ exports[`InputField matches snapshot 1`] = `
     autoFocus={false}
     clickAction={[Function]}
     disabled={false}
-    readonly={true}
     theme={
       Object {
         "COLOR_BACKGROUND_DEFAULT": "hsl(0,0%,100%)",

--- a/src/components/Textarea/Textarea.js
+++ b/src/components/Textarea/Textarea.js
@@ -18,12 +18,13 @@ export default function Textarea({
   labelPosition,
   maxLength,
   placeholder,
+  value,
   ...props
 }) {
   return (
     <InputWrap labelPosition={labelPosition}>
       {label && <InputLabelText>{label}</InputLabelText>}
-      {displayAsText && <InputLabelValue>{props.value}</InputLabelValue>}
+      {displayAsText && <InputLabelValue>{value}</InputLabelValue>}
       {!displayAsText && (
         <>
           <TextareaField
@@ -52,7 +53,8 @@ Textarea.propTypes = {
   labelPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
   maxLength: PropTypes.number,
   placeholder: PropTypes.string,
-  readonly: PropTypes.bool
+  readonly: PropTypes.bool,
+  value: PropTypes.oneOf(["string", "number"])
 };
 
 Textarea.defaultProps = {

--- a/src/components/Textarea/Textarea.js
+++ b/src/components/Textarea/Textarea.js
@@ -5,12 +5,14 @@ import InputLabelText from "components/util/InputLabelText";
 import InputWrap from "components/util/InputWrap";
 import InputHint from "components/util/InputHint";
 import TextareaField from "components/util/TextareaField";
+import InputLabelValue from "components/util/InputLabelValue";
 
 export default function Textarea({
   autoFocus,
   defaultValue,
   readonly,
   disabled,
+  displayAsText,
   hint,
   label,
   labelPosition,
@@ -21,16 +23,21 @@ export default function Textarea({
   return (
     <InputWrap labelPosition={labelPosition}>
       {label && <InputLabelText>{label}</InputLabelText>}
-      <TextareaField
-        autoFocus={autoFocus}
-        defaultValue={defaultValue}
-        disabled={disabled}
-        readonly={readonly}
-        maxLength={maxLength}
-        placeholder={placeholder}
-        {...props}
-      />
-      {hint && <InputHint>{hint}</InputHint>}
+      {displayAsText && <InputLabelValue>{props.value}</InputLabelValue>}
+      {!displayAsText && (
+        <>
+          <TextareaField
+            autoFocus={autoFocus}
+            defaultValue={defaultValue}
+            disabled={disabled}
+            readonly={readonly}
+            maxLength={maxLength}
+            placeholder={placeholder}
+            {...props}
+          />
+          {hint && <InputHint>{hint}</InputHint>}
+        </>
+      )}
     </InputWrap>
   );
 }
@@ -39,6 +46,7 @@ Textarea.propTypes = {
   autoFocus: PropTypes.bool,
   defaultValue: PropTypes.string,
   disabled: PropTypes.bool,
+  displayAsText: PropTypes.bool,
   hint: PropTypes.string,
   label: PropTypes.string,
   labelPosition: PropTypes.oneOf(["top", "bottom", "left", "right"]),
@@ -48,6 +56,7 @@ Textarea.propTypes = {
 };
 
 Textarea.defaultProps = {
+  displayAsText: false,
   labelPosition: "top"
 };
 

--- a/src/components/util/InputLabelText.js
+++ b/src/components/util/InputLabelText.js
@@ -3,7 +3,7 @@ import { keen } from "style/theme";
 
 const InputLabelText = styled.p`
   margin: 0;
-  font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_DEFAULT};
+  font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_SM};
   line-height: ${({ theme }) => theme.LINE_HEIGHT_TIGHT};
 `;
 

--- a/src/components/util/InputLabelValue.js
+++ b/src/components/util/InputLabelValue.js
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+import { keen } from "style/theme";
+
+const InputLabelValue = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_DEFAULT};
+  line-height: ${({ theme }) => theme.LINE_HEIGHT_TIGHT};
+  color: ${({ theme }) => theme.COLOR_CONTENT_DEFAULT};
+`;
+
+InputLabelValue.defaultProps = {
+  theme: keen
+};
+
+export default InputLabelValue;

--- a/src/components/util/__snapshots__/InputLabelText.test.js.snap
+++ b/src/components/util/__snapshots__/InputLabelText.test.js.snap
@@ -3,7 +3,7 @@
 exports[`InputLabel matches snapshot 1`] = `
 .c0 {
   margin: 0;
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1.2;
 }
 

--- a/src/components/util/__snapshots__/InputWrap.test.js.snap
+++ b/src/components/util/__snapshots__/InputWrap.test.js.snap
@@ -3,7 +3,7 @@
 exports[`InputHint matches snapshot 1`] = `
 .c0 {
   margin: 0;
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1.2;
 }
 


### PR DESCRIPTION
This PR adds a `displayAsText` option to inputs.  To only display text rather than a disabled or readonly input.