### PR TITLE
fix: add options back to observer

### DIFF
--- a/src/components/Collapse/Collapse.js
+++ b/src/components/Collapse/Collapse.js
@@ -66,7 +66,9 @@ class Collapse extends React.Component {
           this.observer = new MutationObserver(this.onChildResize);
           contentNodes.forEach(n => {
             this.observer.observe(n, {
-              attributes: true
+              attributes: true,
+              subtree: true,
+              childList: true
             });
           });
         }

--- a/src/components/Collapse/Collapse.js
+++ b/src/components/Collapse/Collapse.js
@@ -66,6 +66,7 @@ class Collapse extends React.Component {
           this.observer = new MutationObserver(this.onChildResize);
           contentNodes.forEach(n => {
             this.observer.observe(n, {
+              // observe changes to child elements
               attributes: true,
               subtree: true,
               childList: true

--- a/src/components/Collapse/__snapshots__/Collapse.test.js.snap
+++ b/src/components/Collapse/__snapshots__/Collapse.test.js.snap
@@ -13,7 +13,6 @@ exports[`Collapse matches snapshot 1`] = `
   width: 100%;
   -webkit-transition: all 0.25s ease;
   transition: all 0.25s ease;
-  min-height: 3.4rem;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
   border-top: 1px solid hsla(0,0%,0%,8%);
 }
@@ -273,7 +272,7 @@ exports[`Collapse matches snapshot 1`] = `
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
-              "width:100%;transition:all 0.25s ease;min-height:3.4rem;font-family:",
+              "width:100%;transition:all 0.25s ease;font-family:",
               [Function],
               ";border-top:1px solid ",
               [Function],

--- a/src/components/Collapse/components/Wrapper.js
+++ b/src/components/Collapse/components/Wrapper.js
@@ -5,7 +5,6 @@ import { keen } from "style/theme";
 export const Wrapper = styled.section`
   width: 100%;
   transition: all 0.25s ease;
-  min-height: 3.4rem;
   font-family: ${({ theme }) => theme.FONT_STACK_DEFAULT};
   border-top: 1px solid ${({ theme }) => theme.COLOR_KEYLINE_DEFAULT};
 

--- a/src/components/Collapse/components/__snapshots__/index.test.js.snap
+++ b/src/components/Collapse/components/__snapshots__/index.test.js.snap
@@ -80,7 +80,6 @@ exports[`Collapse components Wrapper should match snapshot 1`] = `
   width: 100%;
   -webkit-transition: all 0.25s ease;
   transition: all 0.25s ease;
-  min-height: 3.4rem;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
   border-top: 1px solid hsla(0,0%,0%,8%);
 }


### PR DESCRIPTION
I removed some options that I thought were unnecessary from the mutation observer, but obviously they weren't!

To test:

- run storybook
- link to the dashboard if you want and test the route slos