### PR TITLE
chore: npm package license match license

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A library of reusable UI components for the Grey Matter product suite.",
   "main": "lib/build.js",
   "author": "Decipher Technology Studios",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git@github.com:DecipherNow/gm-ui-components.git"


### PR DESCRIPTION
Update NPM registry to show license as MIT.

Issue #527