### PR TITLE
fix: hide delimiter prop

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -38,6 +38,7 @@ export const Breadcrumb = styled.li`
 
   &:before {
     display: inline-block;
+    visibility: ${({ hideDelimiter }) => (hideDelimiter ? "hidden" : "auto")};
     color: ${({ theme }) => theme.COLOR_CONTENT_NONESSENTIAL};
     padding: 0 ${spacingScale(0.5)};
     content: ">";

--- a/src/components/Breadcrumbs/Breadcrumbs.test.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.js
@@ -39,4 +39,14 @@ describe("Breadcrumb", () => {
   test("matches snapshot", () => {
     expect(wrapper).toMatchSnapshot();
   });
+
+  test("hides delimiter when hideDelimiter prop is passed", () => {
+    let options = {
+      modifier: ":before"
+    };
+    wrapper = mount(<Breadcrumb />); // mount in order to use toHaveStyleRule
+    expect(wrapper).toHaveStyleRule("visibility", "auto", options);
+    wrapper = mount(<Breadcrumb hideDelimiter={true} />);
+    expect(wrapper).toHaveStyleRule("visibility", "hidden", options);
+  });
 });

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.js.snap
@@ -23,6 +23,7 @@ exports[`Breadcrumb matches snapshot 1`] = `
 
 .c0:before {
   display: inline-block;
+  visibility: auto;
   color: hsla(0,0%,0%,0.3);
   padding: 0  calc(var(--SPACING_BASE) * 0.5 * 1px);
   content: ">";


### PR DESCRIPTION
Proposed Changes
- set visibility hidden when hideDelimiter is true
- add test

To Test
- run storybook and confirm that hideDelimiter knob actually hides the delimiter