### PR TITLE
fix: remove explicit disabled prop from tabwrap

### DIFF
--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -7,18 +7,12 @@ import TabLabel from "./components/TabLabel";
 const Tab = ({
   label = "",
   active = false,
-  disabled = false,
   children,
   clickAction,
   ...props
 }) => {
   return (
-    <TabWrap
-      active={active}
-      disabled={disabled}
-      onClick={clickAction}
-      {...props}
-    >
+    <TabWrap active={active} onClick={clickAction} {...props}>
       {children}
       <TabLabel>{label}</TabLabel>
     </TabWrap>
@@ -29,7 +23,6 @@ Tab.propTypes = {
   active: PropTypes.bool,
   children: PropTypes.any,
   clickAction: PropTypes.func.isRequired,
-  disabled: PropTypes.bool,
   label: PropTypes.string.isRequired
 };
 

--- a/src/components/Tab/Tab.stories.js
+++ b/src/components/Tab/Tab.stories.js
@@ -34,7 +34,7 @@ stories
           clickAction={() => alert("hello")}
           label={text("label", "Filters")}
           active={boolean("active", false)}
-          disabled={boolean("disabled", false)}
+          disabled={boolean("disabled")}
         />
       );
     },

--- a/src/components/Tab/__snapshots__/Tab.test.js.snap
+++ b/src/components/Tab/__snapshots__/Tab.test.js.snap
@@ -41,7 +41,6 @@ exports[`Tab matches snapshot 1`] = `
 
 <a
   className="c0"
-  disabled={false}
   onClick={[Function]}
 >
   <span

--- a/src/components/Tab/components/TabWrap.js
+++ b/src/components/Tab/components/TabWrap.js
@@ -15,9 +15,7 @@ const downStyles = css`
   box-shadow: ${({ theme }) => theme.COLOR_INTENT_HIGHLIGHT} 0px -2px inset;
 `;
 
-const TabWrap = styled.a.attrs(props => ({
-  disabled: props.disabled
-}))`
+const TabWrap = styled.a`
   font-family: ${({ theme }) => theme.FONT_STACK_DEFAULT};
   font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_DEFAULT};
   color: ${({ theme }) => theme.COLOR_CONTENT_DEFAULT};

--- a/src/components/TabGroup/__snapshots__/TabGroup.test.js.snap
+++ b/src/components/TabGroup/__snapshots__/TabGroup.test.js.snap
@@ -81,7 +81,6 @@ exports[`TabGroup matches snapshot 1`] = `
   </p>
   <a
     className="c2"
-    disabled={false}
     onClick={[Function]}
   >
     <span


### PR DESCRIPTION
Fixes #537

- Removes unnecessary explicit `disabled` prop from Tab component.