### PR TITLE
feat: tab focus styles and polish

### DIFF
--- a/src/components/Tab/Tab.stories.js
+++ b/src/components/Tab/Tab.stories.js
@@ -16,6 +16,7 @@ stories
           label={text("label", "label")}
           active={boolean("active", true)}
           disabled={boolean("disabled")}
+          tabIndex="0"
         />
       );
     },
@@ -35,6 +36,7 @@ stories
           label={text("label", "Filters")}
           active={boolean("active", false)}
           disabled={boolean("disabled")}
+          tabIndex="0"
         />
       );
     },

--- a/src/components/Tab/__snapshots__/Tab.test.js.snap
+++ b/src/components/Tab/__snapshots__/Tab.test.js.snap
@@ -5,8 +5,7 @@ exports[`Tab matches snapshot 1`] = `
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
   font-size: 14px;
   color: hsla(0,0%,0%,0.85);
-  padding-left: calc(var(--SPACING_BASE) * 2 * 1px);
-  padding-right: calc(var(--SPACING_BASE) * 2 * 1px);
+  padding: calc(var(--SPACING_BASE) * 0.5 * 1px)  calc(var(--SPACING_BASE) * 2 * 1px);
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -39,6 +38,18 @@ exports[`Tab matches snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:not(:hover):focus {
+  outline: 2px solid rgba(0,180,43,0.5);
+}
+
+.c0:not(:hover):focus:active {
+  outline: 2px solid rgba(0,180,43,0.7);
 }
 
 .c1 {

--- a/src/components/Tab/__snapshots__/Tab.test.js.snap
+++ b/src/components/Tab/__snapshots__/Tab.test.js.snap
@@ -23,14 +23,22 @@ exports[`Tab matches snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  -webkit-transition: box-shadow 0.15s ease;
+  transition: box-shadow 0.15s ease;
 }
 
 .c0:hover {
-  box-shadow: #00b42b 0px -1px inset;
+  box-shadow: rgba(0,180,43,0.5) 0px -2px inset;
 }
 
 .c0:active {
-  box-shadow: #00b42b 0px -2px inset;
+  box-shadow: rgba(0,180,43,0.7) 0px -2px inset;
+  -webkit-transition-duration: 0;
+  transition-duration: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c1 {

--- a/src/components/Tab/components/TabWrap.js
+++ b/src/components/Tab/components/TabWrap.js
@@ -42,6 +42,28 @@ const TabWrap = styled.a`
     user-select: none;
   }
 
+  &:focus {
+    outline: none;
+  }
+
+  &:not(:hover):focus {
+    outline: 2px solid
+      ${({ theme }) =>
+        transparentize(
+          1 - theme.OPACITY_LIGHTER,
+          theme.COLOR_INTENT_HIGHLIGHT
+        )};
+
+    &:active {
+      outline: 2px solid
+        ${({ theme }) =>
+          transparentize(
+            1 - theme.OPACITY_LIGHT,
+            theme.COLOR_INTENT_HIGHLIGHT
+          )};
+    }
+  }
+
   /* if active... */
   ${props =>
     props.active &&

--- a/src/components/Tab/components/TabWrap.js
+++ b/src/components/Tab/components/TabWrap.js
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import { transparentize } from "polished";
 
 import { spacingScale } from "style/styleFunctions";
 import { keen } from "style/theme";
@@ -8,24 +9,28 @@ const activeStyles = css`
 `;
 
 const hoverStyles = css`
-  box-shadow: ${({ theme }) => theme.COLOR_INTENT_HIGHLIGHT} 0px -1px inset;
+  box-shadow: ${({ theme }) =>
+      transparentize(1 - theme.OPACITY_LIGHTER, theme.COLOR_INTENT_HIGHLIGHT)}
+    0px -2px inset;
 `;
 
 const downStyles = css`
-  box-shadow: ${({ theme }) => theme.COLOR_INTENT_HIGHLIGHT} 0px -2px inset;
+  box-shadow: ${({ theme }) =>
+      transparentize(1 - theme.OPACITY_LIGHT, theme.COLOR_INTENT_HIGHLIGHT)}
+    0px -2px inset;
 `;
 
 const TabWrap = styled.a`
   font-family: ${({ theme }) => theme.FONT_STACK_DEFAULT};
   font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_DEFAULT};
   color: ${({ theme }) => theme.COLOR_CONTENT_DEFAULT};
-  padding-left: ${spacingScale(2)};
-  padding-right: ${spacingScale(2)};
+  padding: ${spacingScale(0.5)} ${spacingScale(2)};
   flex: 0 0 auto;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: box-shadow 0.15s ease;
 
   &:hover {
     ${hoverStyles};
@@ -33,6 +38,8 @@ const TabWrap = styled.a`
 
   &:active {
     ${downStyles};
+    transition-duration: 0;
+    user-select: none;
   }
 
   /* if active... */

--- a/src/components/TabGroup/TabGroup.stories.js
+++ b/src/components/TabGroup/TabGroup.stories.js
@@ -12,9 +12,9 @@ stories.add(
   () => {
     return (
       <TabGroup label={text("label")}>
-        <Tab clickAction={() => {}} label="Active Tab" active />
-        <Tab clickAction={() => {}} label="Label" />
-        <Tab clickAction={() => {}} label="Disabled" disabled />
+        <Tab clickAction={() => {}} label="Active Tab" tabIndex="0" active />
+        <Tab clickAction={() => {}} label="Label" tabIndex="0" />
+        <Tab clickAction={() => {}} label="Disabled" tabIndex="0" disabled />
       </TabGroup>
     );
   },

--- a/src/components/TabGroup/__snapshots__/TabGroup.test.js.snap
+++ b/src/components/TabGroup/__snapshots__/TabGroup.test.js.snap
@@ -23,14 +23,22 @@ exports[`TabGroup matches snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  -webkit-transition: box-shadow 0.15s ease;
+  transition: box-shadow 0.15s ease;
 }
 
 .c2:hover {
-  box-shadow: #00b42b 0px -1px inset;
+  box-shadow: rgba(0,180,43,0.5) 0px -2px inset;
 }
 
 .c2:active {
-  box-shadow: #00b42b 0px -2px inset;
+  box-shadow: rgba(0,180,43,0.7) 0px -2px inset;
+  -webkit-transition-duration: 0;
+  transition-duration: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c3 {

--- a/src/components/TabGroup/__snapshots__/TabGroup.test.js.snap
+++ b/src/components/TabGroup/__snapshots__/TabGroup.test.js.snap
@@ -5,8 +5,7 @@ exports[`TabGroup matches snapshot 1`] = `
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Roboto","Oxygen","Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
   font-size: 14px;
   color: hsla(0,0%,0%,0.85);
-  padding-left: calc(var(--SPACING_BASE) * 2 * 1px);
-  padding-right: calc(var(--SPACING_BASE) * 2 * 1px);
+  padding: calc(var(--SPACING_BASE) * 0.5 * 1px)  calc(var(--SPACING_BASE) * 2 * 1px);
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
@@ -39,6 +38,18 @@ exports[`TabGroup matches snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:not(:hover):focus {
+  outline: 2px solid rgba(0,180,43,0.5);
+}
+
+.c2:not(:hover):focus:active {
+  outline: 2px solid rgba(0,180,43,0.7);
 }
 
 .c3 {


### PR DESCRIPTION
- Adds focus styles to tabs
- Tabs no longer transition the size of their highlight, only the opacity. This makes for a smoother transition and a cleaner appearance.

<img width="299" alt="image" src="https://user-images.githubusercontent.com/98312/63640731-2c1a4000-c672-11e9-9493-9f2841f9632c.png">
