### PR TITLE
fix: center spinner loading message

### DIFF
--- a/src/components/Spinner/components/LoadingMessage.js
+++ b/src/components/Spinner/components/LoadingMessage.js
@@ -4,7 +4,8 @@ import { keen } from "style/theme";
 export const LoadingMessage = styled.p`
   color: ${({ theme }) => theme.COLOR_CONTENT_MUTED};
   font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_XS};
-  max-width: 50%;
+  width: max-content;
+  max-width: 20em;
   margin: 0;
 `;
 

--- a/src/components/Spinner/components/__snapshots__/LoadingMessage.test.js.snap
+++ b/src/components/Spinner/components/__snapshots__/LoadingMessage.test.js.snap
@@ -4,7 +4,10 @@ exports[`LoadingMessage matches snapshot 1`] = `
 .c0 {
   color: hsla(0,0%,0%,0.6);
   font-size: 10px;
-  max-width: 50%;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 20em;
   margin: 0;
 }
 


### PR DESCRIPTION
Centers the loading message under the spinner.

<img width="206" alt="Screen Shot 2020-07-27 at 10 23 21 AM" src="https://user-images.githubusercontent.com/98312/88553371-33209f80-cff3-11ea-89a0-71abd6b2a03e.png">
