### PR TITLE
feat: added badge component

### DIFF
--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+import { readableColor } from "polished";
+
+import { spacingScale } from "style/styleFunctions";
+import { keen, keenDark } from "style/theme";
+
+const Badge = styled.span`
+  font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_SM};
+  font-weight: 500;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  line-height: 0.9;
+  height: fit-content;
+  padding: ${spacingScale(0.15)} ${spacingScale(1)} ${spacingScale(0.15)}
+    ${spacingScale(0.5)};
+  background-color: ${props => props.color || props.theme.COLOR_BRAND_PRIMARY};
+  border-radius: ${({ theme }) => parseInt(theme.CORNER_RADIUS_CARD_SM, 10)}px;
+  color: ${props =>
+    readableColor(
+      props.color || props.theme.COLOR_BACKGROUND_DEFAULT,
+      keen.COLOR_CONTENT_DEFAULT,
+      keenDark.COLOR_CONTENT_DEFAULT
+    )};
+  margin-right: ${spacingScale(0.5)};
+  white-space: nowrap;
+
+  svg:first-child {
+    margin: -100% -${spacingScale(0.5)};
+  }
+`;
+
+export default Badge;

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -1,26 +1,25 @@
 import styled from "styled-components";
-import { readableColor } from "polished";
+import { readableColor, darken } from "polished";
 
 import { spacingScale } from "style/styleFunctions";
 import { keen, keenDark } from "style/theme";
 
 const Badge = styled.span`
   font-size: ${({ theme }) => theme.FONT_SIZE_TEXT_SM};
-  font-weight: 500;
+  font-weight: ${({ theme }) => theme.FONT_WEIGHT_SEMIBOLD};
   text-align: center;
   display: flex;
   align-items: center;
   line-height: 0.9;
   height: fit-content;
-  padding: ${spacingScale(0.15)} ${spacingScale(1)} ${spacingScale(0.15)}
-    ${spacingScale(0.5)};
+  padding: ${spacingScale(0.5)};
   background-color: ${props => props.color || props.theme.COLOR_BRAND_PRIMARY};
-  border-radius: ${({ theme }) => parseInt(theme.CORNER_RADIUS_CARD_SM, 10)}px;
+  border-radius: ${({ theme }) => theme.CORNER_RADIUS_CARD_SM};
   color: ${props =>
     readableColor(
-      props.color || props.theme.COLOR_BACKGROUND_DEFAULT,
-      keen.COLOR_CONTENT_DEFAULT,
-      keenDark.COLOR_CONTENT_DEFAULT
+      darken(0.12, props.color || props.theme.COLOR_BACKGROUND_DEFAULT),
+      keen.COLOR_CONTENT_CONTRAST,
+      keenDark.COLOR_CONTENT_CONTRAST
     )};
   margin-right: ${spacingScale(0.5)};
   white-space: nowrap;

--- a/src/components/Badge/Badge.stories.js
+++ b/src/components/Badge/Badge.stories.js
@@ -5,31 +5,10 @@ import Badge from "./Badge";
 
 const stories = storiesOf("Components|Badge", module);
 
-stories
-  .add(
-    "Default",
-    () => {
-      return (
-        <Badge color={color("blue")}>{text("label", "Hello World")}</Badge>
-      );
-    },
-    {}
-  )
-  .add(
-    "With limited container size",
-    () => {
-      return (
-        <div
-          style={{
-            width: "350px",
-            border: "1px solid #ddd",
-            padding: "4px",
-            borderRadius: "2px"
-          }}
-        >
-          <Badge color={color("blue")}>{text("label", "Hello World")}</Badge>
-        </div>
-      );
-    },
-    {}
-  );
+stories.add(
+  "Default",
+  () => {
+    return <Badge color={color("blue")}>{text("label", "Hello World")}</Badge>;
+  },
+  {}
+);

--- a/src/components/Badge/Badge.stories.js
+++ b/src/components/Badge/Badge.stories.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { array, boolean, text, color } from "@storybook/addon-knobs";
+import Badge from "./Badge";
+
+const stories = storiesOf("Components|Badge", module);
+
+stories
+  .add(
+    "Default",
+    () => {
+      return (
+        <Badge color={color("blue")}>{text("label", "Hello World")}</Badge>
+      );
+    },
+    {}
+  )
+  .add(
+    "With limited container size",
+    () => {
+      return (
+        <div
+          style={{
+            width: "350px",
+            border: "1px solid #ddd",
+            padding: "4px",
+            borderRadius: "2px"
+          }}
+        >
+          <Badge color={color("blue")}>{text("label", "Hello World")}</Badge>
+        </div>
+      );
+    },
+    {}
+  );

--- a/src/components/Badge/Badge.stories.js
+++ b/src/components/Badge/Badge.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { array, boolean, text, color } from "@storybook/addon-knobs";
+import { text, color } from "@storybook/addon-knobs";
 import Badge from "./Badge";
 
 const stories = storiesOf("Components|Badge", module);

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,0 +1,2 @@
+import Badge from "./Badge";
+export default Badge;


### PR DESCRIPTION
closes #281 

- add badge component from [dashboard](https://github.com/DecipherNow/gm-dashboard/blob/release-3.5/src/style/components/Badge.js#L1)